### PR TITLE
sandbox/update-version: Use "/usr/bin/env bash" instead of "/bin/bash" && Use UTC as timezone.

### DIFF
--- a/sandbox/update-version
+++ b/sandbox/update-version
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-export TZ="/usr/share/zoneinfo/UTC" # Use UTC with version timestamps.
+export TZ="/usr/share/zoneinfo/UTC" # Set timezone as UTC for version timestamps to be in UTC.
 echo "Updating version..."
 perl -pi -e  "s/^version\s*=\s*['\"]([\S]+)[ '\"].*/version = '\1 ($( date -Iseconds ))'/" src/version.py
 unset TZ # Return to the system timezone.


### PR DESCRIPTION
1. "/usr/bin/env bash" works on more systems than "/bin/bash", because bash isn't always in /bin.
2. If everyone used same timezone in version numbers, reading of them would be more easier. See also that commit message.
