### PR TITLE
Calling "urlquote" on an url in _getGooUrl causes "http://" to be prepended to the url

### DIFF
--- a/plugins/ShrinkUrl/plugin.py
+++ b/plugins/ShrinkUrl/plugin.py
@@ -236,7 +236,6 @@ class ShrinkUrl(callbacks.PluginRegexp):
 
     _gooApi = 'https://www.googleapis.com/urlshortener/v1/url'
     def _getGooUrl(self, url):
-        url = utils.web.urlquote(url)
         try:
             return self.db.get('goo', url)
         except KeyError:


### PR DESCRIPTION
Shortening an url that stars with "http://myurl.com/blah/blah" leads to urls like "http://http//myurl.com/blah/blah" when using the goo.gl shortener. Removing "urlquote" solves this problem.

With urlencode, the json becomes '{"longUrl": "http%3A//foo.bar/foo/bar"}' which, of course, does not work. simplejson handles any encoding the string might need.
