### PR TITLE
Conditional: Add description about plugin to init

### DIFF
--- a/plugins/Conditional/__init__.py
+++ b/plugins/Conditional/__init__.py
@@ -28,9 +28,10 @@
 
 ###
 
+
 """
-Add a description of the plugin (to be presented to the user inside the wizard)
-here.  This should describe *what* the plugin does.
+Contains numerous conditional commands (such as 'if', 'and', and 'or'),
+which can be used on their own or with another plugin.
 """
 
 import supybot


### PR DESCRIPTION
Fixes the issue in supybot-wizard which shows this type of output:

What plugin would you like to look at? [.../Conditional/...] Conditional

Add a description of the plugin (to be presented to the user inside the wizard)
here.  This should describe _what_ the plugin does.

 Would you like to load this plugin? [y/n](default: y)
