### PR TITLE
Added a way to have the urlsnarfer report exceptions (hotsnotnound, ...)

### DIFF
--- a/plugins/Web/config.py
+++ b/plugins/Web/config.py
@@ -49,6 +49,9 @@ Web = conf.registerPlugin('Web')
 conf.registerChannelValue(Web, 'titleSnarfer',
     registry.Boolean(False, _("""Determines whether the bot will output the
     HTML title of URLs it sees in the channel.""")))
+conf.registerChannelValue(Web, 'snarferReportIOExceptions',
+    registry.Boolean(False, _("""Determines whether the bot will notfiy the user
+    about network exceptions like hostnotfound, timeout ....""")))
 conf.registerChannelValue(Web, 'nonSnarfingRegexp',
     registry.Regexp(None, _("""Determines what URLs matching the given regexp
     will not be snarfed.  Give the empty string if you have no URLs that you'd

--- a/plugins/Web/plugin.py
+++ b/plugins/Web/plugin.py
@@ -97,6 +97,8 @@ class Web(callbacks.PluginRegexp):
                     text = text.decode('utf8', 'replace')
             except utils.web.Error, e:
                 self.log.info('Couldn\'t snarf title of %u: %s.', url, e)
+                if self.registryValue('snarferReportIOExceptions', channel):
+                     irc.reply(url+" : "+utils.web.strError(e), prefixNick=False)
                 return
             parser = Title()
             try:


### PR DESCRIPTION
(Should be possible changed to only ioExceptions)
Enable/Disable via 'supybot.plugins.Web.snarferReportIOExceptions'

greetings,
SleepProgger
