### PR TITLE
Consider switching from chardet to charade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
   - "pypy"
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
-  - pip install pytz feedparser chardet --use-mirrors
+  - pip install pytz feedparser charade --use-mirrors
 # command to run tests, e.g. python setup.py test
 script:
   - echo $TRAVIS_PYTHON_VERSION

--- a/src/drivers/Socket.py
+++ b/src/drivers/Socket.py
@@ -46,13 +46,13 @@ import supybot.drivers as drivers
 import supybot.schedule as schedule
 from itertools import imap
 try:
-    from chardet.universaldetector import UniversalDetector
-    chardetLoaded = True
+    from charade.universaldetector import UniversalDetector
+    charadeLoaded = True
 except:
-    drivers.log.debug('chardet module not available, '
+    drivers.log.debug('charade module not available, '
                       'cannot guess character encoding if'
                       'using Python3')
-    chardetLoaded = False
+    charadeLoaded = False
 try:
     import ssl
     SSLError = ssl.SSLError
@@ -198,8 +198,8 @@ class SocketDriver(drivers.IrcDriver, drivers.ServersMixin):
                     try:
                         line = line.decode('utf8', 'strict')
                     except UnicodeError:
-                        # if this fails and chardet is loaded, try to guess the correct encoding
-                        if chardetLoaded:
+                        # if this fails and charade is loaded, try to guess the correct encoding
+                        if charadeLoaded:
                             u = UniversalDetector()
                             u.feed(line)
                             u.close()
@@ -215,11 +215,11 @@ class SocketDriver(drivers.IrcDriver, drivers.ServersMixin):
                                 # if no encoding could be guessed, fall back to utf-8 and
                                 # replace offending characters
                                 line = line.decode('utf8', 'replace')
-                        # if chardet is not loaded, try to decode using utf-8 and replace any
+                        # if charade is not loaded, try to decode using utf-8 and replace any
                         # offending characters
                         else:
                             line = line.decode('utf8', 'replace')
-           
+
                 msg = drivers.parseMsg(line)
                 if msg is not None:
                     self.irc.feedMsg(msg)

--- a/src/utils/web.py
+++ b/src/utils/web.py
@@ -195,8 +195,8 @@ def htmlToText(s, tagReplace=' '):
     """Turns HTML into text.  tagReplace is a string to replace HTML tags with.
     """
     try:
-        import chardet.universaldetector
-        u = chardet.universaldetector.UniversalDetector()
+        import charade.universaldetector
+        u = charade.universaldetector.UniversalDetector()
         u.feed(s)
         u.close()
         s = s.decode(u.result['encoding'])


### PR DESCRIPTION
I think chardet has not been maintained for a while now and it's not easy to choose between the several forks.
[Charade](https://github.com/sigmavirus24/charade) has some improvements and should work out of the box.

Pros:
- works with python >= 2.6 and python 3
- drop-in replacement

Cons:
- feedparser needs to be updated as well (but RSS plugin is broken with it currently anyway)

It would also be also possible to do something like "import charade as chardet" and then on exception import chardet to ease the switch.

(On a sidenote: I am new to github, hope i have everything done well...) 
