### PR TITLE
Seen: Change 'last left the #channelname' to 'last left #channelname' in the English error message.

### DIFF
--- a/plugins/Seen/locales/de.po
+++ b/plugins/Seen/locales/de.po
@@ -123,7 +123,7 @@ msgid "%s must be in %s to use this command."
 msgstr "Du musst in %s sein, um diesen Befehl zu benutzen."
 
 #: plugin.py:334
-msgid "I couldn't find in my history of %s messages where %r last left the %s"
+msgid "I couldn't find in my history of %s messages where %r last left %s"
 msgstr "Ich konnte in meiner Vergangenheit von %s Nachrichten nichts finden, wo %r zuletzt %s verlassen hat."
 
 #: plugin.py:343

--- a/plugins/Seen/locales/fi.po
+++ b/plugins/Seen/locales/fi.po
@@ -142,7 +142,7 @@ msgid "%s must be in %s to use this command."
 msgstr "Käyttäjän %s täytyy olla kanavalla %s käyttääkseen tätä komentoa."
 
 #: plugin.py:334
-msgid "I couldn't find in my history of %s messages where %r last left the %s"
+msgid "I couldn't find in my history of %s messages where %r last left %s"
 msgstr "En voinut löytää %s viestin historiasta milloin %r viimeksi lähti kanavalta %s"
 
 #: plugin.py:343

--- a/plugins/Seen/locales/fr.po
+++ b/plugins/Seen/locales/fr.po
@@ -154,7 +154,7 @@ msgid "%s must be in %s to use this command."
 msgstr "%s doit être dans %s pour utiliser cette commande."
 
 #: plugin.py:352
-msgid "I couldn't find in my history of %s messages where %r last left the %s"
+msgid "I couldn't find in my history of %s messages where %r last left %s"
 msgstr ""
 "Je ne peux pas trouver dans mon historique de %s messages, où %r a quitté il "
 "y a %s"

--- a/plugins/Seen/locales/it.po
+++ b/plugins/Seen/locales/it.po
@@ -139,7 +139,7 @@ msgid "%s must be in %s to use this command."
 msgstr "Per usare questo comando %s deve essere in %s."
 
 #: plugin.py:334
-msgid "I couldn't find in my history of %s messages where %r last left the %s"
+msgid "I couldn't find in my history of %s messages where %r last left %s"
 msgstr "Non trovo nella cronologia dei messaggi di %s dove %r ha lasciato %s l'ultima volta."
 
 #: plugin.py:343

--- a/plugins/Seen/messages.pot
+++ b/plugins/Seen/messages.pot
@@ -135,7 +135,7 @@ msgid "%s must be in %s to use this command."
 msgstr ""
 
 #: plugin.py:363
-msgid "I couldn't find in my history of %s messages where %r last left the %s"
+msgid "I couldn't find in my history of %s messages where %r last left %s"
 msgstr ""
 
 #: plugin.py:372

--- a/plugins/Seen/plugin.py
+++ b/plugins/Seen/plugin.py
@@ -361,7 +361,7 @@ class Seen(callbacks.Plugin):
                 break
         else: # I never use this; it only kicks in when the for loop exited normally.
             irc.error(format(_('I couldn\'t find in my history of %s messages '
-                             'where %r last left the %s'),
+                             'where %r last left %s'),
                              len(irc.state.history), nick, channel))
             return
         msgs = [m for m in irc.state.history[i:end]


### PR DESCRIPTION
It is my opinion that this is a better way to write this error message.

Only the English part is updated.
