### PR TITLE
Google: Filter out [, before attempting to interpret Googles response as json

### DIFF
--- a/plugins/Google/plugin.py
+++ b/plugins/Google/plugin.py
@@ -267,6 +267,8 @@ class Google(callbacks.PluginRegexp):
 
         while ',,' in result:
             result = result.replace(',,', ',null,')
+        while '[,' in result:
+            result = result.replace('[,', '[')
         data = json.loads(result)
 
         try:


### PR DESCRIPTION
In Google Translate, with the command
    @google translate es en hecho en mexico!

This is returned from Google (after removing double ,,):
[[["made in mexico !","hecho en mexico!","",""]],null,"es",null,[["made in",[4],1,0,608,0,2,0],["mexico",[5],1,0,967,2,3,0],["!",[6],0,0,967,3,4,0]],[["hecho en",4,[["made in",608,1,0],["done in",4,1,0],["done",0,1,0],["Done at",0,1,0],["is Made in",0,1,0]],[[0,8]],"hecho en mexico!"],["mexico",5,[["mexico",967,1,0]],[[9,15]],""],["!",6,[["!",967,0,0]],[[15,16]],""]],null,[,"hecho en méxico!",[6]],[["es","nl","gl","en","cy"]],3]

Here you have the line
    [,"hecho en méxico!",[6]]
This is not valid JSON.

I propose that all , appearing after [ is removed.
