### PR TITLE
log: Add support for Logging's 'extra' keyword argument

### DIFF
--- a/src/log.py
+++ b/src/log.py
@@ -82,9 +82,10 @@ class Logger(logging.Logger):
         # The traceback should be sufficient if we want it.
         # self.error('Exception string: %s', eStrId)
 
-    def _log(self, level, msg, args, exc_info=None):
+    def _log(self, level, msg, args, exc_info=None, extra=None):
         msg = format(msg, *args)
-        logging.Logger._log(self, level, msg, (), exc_info=exc_info)
+        logging.Logger._log(self, level, msg, (), exc_info=exc_info, 
+                            extra=extra)
 
 
 class StdoutStreamHandler(logging.StreamHandler):


### PR DESCRIPTION
Python 2.5 added the optional keyword argument _extra_ for providing an optional dictionary of user defined attributes (See: [Python 2.7 source](http://hg.python.org/cpython/file/2.7/Lib/logging/__init__.py#l1252)).  

This change mirrors Python's _log so that plugins with custom loggers can utilize this keyword without breaking Limnoria's internal logging. 
