### PR TITLE
Minor fixes

### DIFF
--- a/plugins/ChannelLogger/plugin.py
+++ b/plugins/ChannelLogger/plugin.py
@@ -149,7 +149,7 @@ class ChannelLogger(callbacks.Plugin):
             try:
                 name = self.getLogName(channel)
                 logDir = self.getLogDir(irc, channel)
-                log = open(os.path.join(logDir, name), 'a')
+                log = open(os.path.join(logDir, name), encoding='utf-8', mode='a')
                 logs[channel] = log
                 return log
             except IOError:


### PR DESCRIPTION
Eliminate unnecessary closing of the log file:
  Name returns a string that is the log file name: the channel plus the timestamp.
  But on my system log.name returns the fully qualified path to the currently open file. This is because log is a file handle, so if you declare it with a path, it will be included in the name.
  On systems were logging is not in the current directory, the two will never match, and the file is closed and then reopened.
  Only taking the basename solves this problem.

Ensure UTF-8 encoded log files:
  I had encoding problems, and my research suggested that I needed to be explicit about the encoding while writing the log files to avoid problems across platforms. It didn't turn out to be the cause of my problems, but it still seems like the right way to do it.
