### PR TITLE
Fix incorrect error on loading nonexistent plugin

### DIFF
--- a/plugins/Owner/plugin.py
+++ b/plugins/Owner/plugin.py
@@ -436,7 +436,7 @@ class Owner(callbacks.Plugin):
                       'to force it to load.' % name.capitalize())
             return
         except ImportError as e:
-            if str(e).endswith(' ' + name):
+            if str(e).endswith(name):
                 irc.error('No plugin named %s exists.' % utils.str.dqrepr(name))
             else:
                 irc.error(str(e))


### PR DESCRIPTION
I haven't tested this too thoroughly, but it does seem to fix #546.
At the moment, I'm not sure if there are any other distinct ways to cause ImportError on load.
