### PR TITLE
Fix AttributeError exception in log.py with python3.4

### DIFF
--- a/src/log.py
+++ b/src/log.py
@@ -209,7 +209,10 @@ class ValidLogLevel(registry.String):
     def set(self, s):
         s = s.upper()
         try:
-            level = logging._levelNames[s]
+            try:
+                level = logging._levelNames[s]
+            except AttributeError:
+                level = logging._nameToLevel[s]
         except KeyError:
             try:
                 level = int(s)


### PR DESCRIPTION
This fixes an AttributeError introduced with a change of the logging module in python 3.4.

I've not tested Limnoria with python 3.3 (only 3.2 and 3.4), so I don't know if this issue is present in 3.3.

Sorry for the dupe PR, I've forgot to open it to testing and not to master.

```
Traceback (most recent call last):
  File "/home/sconde/.local/bin/supybot", line 208, in <module>
    import supybot.log as log
  File "/home/sconde/.local/lib/python3.4/site-packages/supybot/log.py", line 253, in <module>
    increasing priority."""))
  File "/home/sconde/.local/lib/python3.4/site-packages/supybot/conf.py", line 81, in registerGlobalValue
    return group.register(name, value)
  File "/home/sconde/.local/lib/python3.4/site-packages/supybot/registry.py", line 268, in register
    node.setName(fullname)
  File "/home/sconde/.local/lib/python3.4/site-packages/supybot/registry.py", line 350, in setName
    self.__parent.setName(*args)
  File "/home/sconde/.local/lib/python3.4/site-packages/supybot/registry.py", line 238, in setName
    self.set(_cache[name])
  File "/home/sconde/.local/lib/python3.4/site-packages/supybot/log.py", line 212, in set
    level = logging._levelNames[s]
AttributeError: 'module' object has no attribute '_levelNames'
```
