### PR TITLE
.travis.yml: add Python 3.4.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "2.7"
   - "3.2"
   - "3.3"
+  - "3.4"
   - "pypy"
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:


### PR DESCRIPTION
According to https://github.com/travis-ci/travis-ci/issues/1989 Travis
will get Python versions from
https://launchpad.net/~fkrull/+archive/deadsnakes
and that PPA has python3.4 so it should be installed to them soon.

Feel free to not merge this until it has happened.
