### PR TITLE
Unix: Fix ProgVal/Limnoria#256

### DIFF
--- a/plugins/Unix/plugin.py
+++ b/plugins/Unix/plugin.py
@@ -245,7 +245,7 @@ class Unix(callbacks.Plugin):
                 with open(os.devnull, 'r+') as null:
                     inst = subprocess.Popen([wtfCmd, something],
                                             stdout=subprocess.PIPE,
-                                            stderr=null,
+                                            stderr=STDOUT,
                                             stdin=null)
             except OSError:
                 irc.error(_('It seems the configured wtf command was not '


### PR DESCRIPTION
Unix.wtf now sends errors to IRC.

```
14:15:44 <@Mikaela> +whatis asdfhaerhyasfh
14:15:47 <@Tessu> Gee... I don't know what asdfhaerhyasfh means...
```

This is the same message which you would get by running `wtf` directly from terminal.
