### PR TITLE
INSTALL.md: make setting PATH as simple as possible.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -100,10 +100,11 @@ registry file for your bot.
 
 By default you must run the bot with full path to the binary unless you specify $PATH.
 
-Run and add the following command to your shellrc, which is usually ~/.bashrc or ~/.zshrc , so you can run the programs without needing to write full paths to the binaries.
+Run the following command to fix your PATH. We presume that you use bash 
+and if you don't, you most probably know how to do this with other shell.
 
 ```
-PATH=$HOME/.local/bin:$PATH
+echo "PATH=$HOME/.local/bin:$PATH" >> ~/.bashrc && source ~/.bashrc
 ```
 
 # Upgrading


### PR DESCRIPTION
Or at least add so simple as possible instructions, one command.

Bash is the most used shell as far as I know and it's used by default everywhere that I know, so people who aren't using it will most probably know to use ~/.zshenv or ~/.zshrc or whatever shell they use rc.
