### PR TITLE
AutoMode: use default settings that make sense.

### DIFF
--- a/plugins/AutoMode/config.py
+++ b/plugins/AutoMode/config.py
@@ -46,26 +46,26 @@ conf.registerChannelValue(AutoMode, 'enable',
     registry.Boolean(True, _("""Determines whether this plugin is enabled.
     """)))
 conf.registerGlobalValue(AutoMode, 'owner',
-    registry.Boolean(True, _("""Determines whether this plugin will automode
+    registry.Boolean(False, _("""Determines whether this plugin will automode
     owners even if they don't have op/halfop/voice/whatever capability.""")))
 conf.registerChannelValue(AutoMode, 'alternativeCapabilities',
     registry.Boolean(False, _("""Determines whether the bot will
     check for 'alternative capabilities' (ie. autoop, autohalfop,
     autovoice) in addition to/instead of classic ones.""")))
 conf.registerChannelValue(AutoMode, 'fallthrough',
-    registry.Boolean(False, _("""Determines whether the bot will "fall
+    registry.Boolean(True, _("""Determines whether the bot will "fall
     through" to halfop/voicing when auto-opping is turned off but
     auto-halfopping/voicing are turned on.""")))
 conf.registerChannelValue(AutoMode, 'op',
-    registry.Boolean(True, _("""Determines whether the bot will automatically
+    registry.Boolean(False, _("""Determines whether the bot will automatically
     op people with the <channel>,op capability when they join the channel.
     """)))
 conf.registerChannelValue(AutoMode, 'halfop',
-    registry.Boolean(True, _("""Determines whether the bot will automatically
+    registry.Boolean(False, _("""Determines whether the bot will automatically
     halfop people with the <channel>,halfop capability when they join the
     channel.""")))
 conf.registerChannelValue(AutoMode, 'voice',
-    registry.Boolean(True, _("""Determines whether the bot will automatically
+    registry.Boolean(False, _("""Determines whether the bot will automatically
     voice people with the <channel>,voice capability when they join the
     channel.""")))
 conf.registerChannelValue(AutoMode, 'ban',


### PR DESCRIPTION
AutoMode is enabled by default, so banning works.

AutoMode doesn't AutoMode owner, because in Limnoria it's not required if owner has the op/whatever capability.

AlternativeCapabilities weren't enabled before by default and they aren't so used anyway.

Fallthrough yes, it makes sense to me. If you enable automoding voiced people, it makes sense that people with higher capability are also voiced.

Op, HalfOp, voice: don't use them as default. It just confuses people like we noticed elsewhere.

Ban: yes, because channel ban.add depends on this to do anything. 

EDIT: Added description about choices that I made. 
