### PR TITLE
Disable Protector by default. (Please read additional description!)

### DIFF
--- a/plugins/Protector/config.py
+++ b/plugins/Protector/config.py
@@ -44,7 +44,7 @@ def configure(advanced):
 
 Protector = conf.registerPlugin('Protector')
 conf.registerChannelValue(Protector, 'enable',
-    registry.Boolean(True, _("""Determines whether this plugin is enabled in a
+    registry.Boolean(False, _("""Determines whether this plugin is enabled in a
     given channel.""")))
 
 class ImmuneNicks(conf.ValidNicks):


### PR DESCRIPTION
We are mostly seeing questions on why does Protector do weird things which
 it does. They can be solved, by disabling Protector by default.

Another issue is that when Protector is loaded, it affects every channel
 where the bot is on. The users most probably want to protect specific
 channels in case all ops etc. aren't registered to the bot in all channels
 where the bot is.
