### PR TITLE
Travis: install depedencies from debian/contol.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
 install:
     - sudo apt-get update -qq
     - sudo apt-get -y install devscripts equivs
-    - mk-build-deps -i debian/control
+    - sudo mk-build-deps -i debian/control
     - pip install -r requirements.txt
 
 # command to run tests, e.g. python setup.py test


### PR DESCRIPTION
This makes Travis create package with build depedencies based on the file debian/control where build depedencies are specified.

I didn't remove pip, because pip is more platform independ and this won't work on other than Debian-based systems. It works on Travis, because they are using Ubuntu.
