### PR TITLE
Karma: make allowUnaddressedKarma True by default & update README.

### DIFF
--- a/plugins/Karma/README.txt
+++ b/plugins/Karma/README.txt
@@ -1,6 +1,6 @@
 This will increase or decrease karma for the item.
 
-If "config plugins.karma.allowUnaddressedKarma" is set to true, saying "boats++" will give 1 karma to "boats", and "ships--" will subtract 1 karma from "ships".
+If "config plugins.karma.allowUnaddressedKarma" is set to true (default since 2014.05.07), saying "boats++" will give 1 karma to "boats", and "ships--" will subtract 1 karma from "ships".
 
 However, if you use this in a sentence, like "That deserves a ++. Kevin++", 1 karma will be added to "That deserves a ++. Kevin", so you should only add or subtract karma in a line that doesn't have anything else in it.
 

--- a/plugins/Karma/config.py
+++ b/plugins/Karma/config.py
@@ -58,7 +58,7 @@ conf.registerChannelValue(Karma, 'allowSelfRating',
     registry.Boolean(False, _("""Determines whether users can adjust the karma
     of their nick.""")))
 conf.registerChannelValue(Karma, 'allowUnaddressedKarma',
-    registry.Boolean(False, _("""Determines whether the bot will
+    registry.Boolean(True, _("""Determines whether the bot will
     increase/decrease karma without being addressed.""")))
 
 # vim:set shiftwidth=4 softtabstop=4 expandtab textwidth=79:


### PR DESCRIPTION
Everyone presumes it's a default if they have used a bot owned by someone else as everyone configures their bots that way (or at least all people whom I know).

Even long time Supybot users think that it's enabled by default.
