### PR TITLE
ShrinkUrl: use x0 by default.

### DIFF
--- a/plugins/ShrinkUrl/config.py
+++ b/plugins/ShrinkUrl/config.py
@@ -88,7 +88,7 @@ conf.registerChannelValue(ShrinkUrl, 'outFilter',
     URLs of outgoing messages if those URLs are longer than
     supybot.plugins.ShrinkUrl.minimumLength.""")))
 conf.registerChannelValue(ShrinkUrl, 'default',
-    ShrinkService('ln', _("""Determines what website the bot will use when
+    ShrinkService('x0', _("""Determines what website the bot will use when
     shrinking a URL.""")))
 conf.registerGlobalValue(ShrinkUrl, 'bold',
     registry.Boolean(True, _("""Determines whether this plugin will bold


### PR DESCRIPTION
 ShrinkUrl: use x0 by default. Fixes #617.

x0 has the smallest working output. ur1 had the second smallest.
Their difference is one character.
