### PR TITLE
debian/control: Replaces supybot

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -13,6 +13,7 @@ Recommends: python-simplejson, python-feedparser, python-sqlite3
 Suggests: python-twisted-core, python-twisted-names, python-dictclient, python-dateutil, python-gnupg, python-sqlalchemy
 Conflicts: supybot
 Provides: supybot
+Replaces: supybot
 Section: net
 Priority: optional
 Homepage: https://github.com/ProgVal/Limnoria


### PR DESCRIPTION
It was just said at #Limnoria that someone couldn't install Debian packages of Limnoria, because haven't been configured to replace supybot.

NOTE: I am not Debian packager, so I have no idea if this works, so please test it first!
