### PR TITLE
Channel.Alert gives success message now. Fixes #544.

### DIFF
--- a/plugins/Channel/plugin.py
+++ b/plugins/Channel/plugin.py
@@ -915,7 +915,7 @@ class Channel(callbacks.Plugin):
             hostmask = irc.state.nickToHostmask(nick)
             if ircdb.checkCapability(hostmask, capability):
                 irc.reply(s, to=nick, private=True)
-        irc.replySucess()
+        irc.replySuccess()
 
     @internationalizeDocstring
     def alert(self, irc, msg, args, channel, text):


### PR DESCRIPTION
This seems to work with my bot.

```
22:32:14 < Mikaela> alert ##Mkaysi again
22:32:14 < Yvzabevn> Alert to all ##Mkaysi ops: again (from Mikaela)
22:32:17 < Yvzabevn> OK.
22:32:29 < Mikaela> alert ##Mkaysi finally.
22:32:30 < Yvzabevn> Alert to all ##Mkaysi ops: finally. (from Mikaela)
22:32:32 < Yvzabevn> OK.
```
