### PR TITLE
Filter: remove unneeded leading space from !spellit output

### DIFF
--- a/plugins/Filter/plugin.py
+++ b/plugins/Filter/plugin.py
@@ -642,7 +642,7 @@ class Filter(callbacks.Plugin):
             except KeyError:
                 pass
             write(c)
-        irc.reply(out.getvalue())
+        irc.reply(out.getvalue()[1:])
     spellit = wrap(spellit, ['text'])
 
     @internationalizeDocstring


### PR DESCRIPTION
Extremely trivial commit, but I didn't see the point in an extra leading space.
