### PR TITLE
requirements.txt: add SocksiPy-branch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ python-dateutil
 python-gnupg
 feedparser
 sqlalchemy
+SocksiPy-branch


### PR DESCRIPTION
It appears to be depedency of Limnoria to be able to use socks proxy. I received this error

```
ERROR 2014-05-18T18:06:21 Cannot use socks proxy (SocksiPy not installed), using direct connection instead.
```

which was fixed by installing `SocksiPy-branch`. Trying to install `SocksiPy` caused complaints from pip, but this seems to have fixed Limnoria*.

```
  Could not find any downloads that satisfy the requirement socksipy
  Some externally hosted files were ignored (use --allow-external socksipy to allow).
```

(*= Now I am only seeing broken pipe.)
