### PR TITLE
Later: make default settings more sane

### DIFF
--- a/plugins/Later/config.py
+++ b/plugins/Later/config.py
@@ -46,10 +46,10 @@ conf.registerGlobalValue(Later, 'maximum',
     messages to be queued for a user.  If this value is 0, there is no maximum.
     """)))
 conf.registerGlobalValue(Later, 'private',
-    registry.Boolean(True, _("""Determines whether users will be notified in
+    registry.Boolean(False, _("""Determines whether users will be notified in
     the first place in which they're seen, or in private.""")))
 conf.registerGlobalValue(Later, 'tellOnJoin',
-    registry.Boolean(True, _("""Determines whether users will be notified upon
+    registry.Boolean(False, _("""Determines whether users will be notified upon
     joining any channel the bot is in, or only upon sending a message.""")))
 conf.registerGlobalValue(Later, 'messageExpiry',
     registry.NonNegativeInteger(30, _("""Determines the maximum number of


### PR DESCRIPTION
**PLEASE DO READ THE WHOLE PULL REQUEST OR COMMIT MESSAGE!**

private: False
- If #653 gets done, notices are much more easier to lose.

tellOnJoin: False
- Many people are using bouncers or running their IRC clients on 24/7 up server, so in many cases joins don't tell anything on are people really present, so it's better to just wait for them to say something.
