### PR TITLE
INSTALL.md: Fix Debian/Ubuntu link.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -45,7 +45,7 @@ from there.
 
 # UNIX/Linux/BSD
 
-If you use [Debian or Ubuntu, click here](INSTALL.md#Debian)
+If you use [Debian or Ubuntu, click here](INSTALL.md#debian)
 
 If you're installing Python using your distributor's packages, you may
 need a python-dev or python3-dev package installed, too.  If you don't have


### PR DESCRIPTION
It seems that markdown converts Debian to lower-case debian and the link goes to upper case Debian which doesn't exist.
