### PR TITLE
src/conf.py: default reply.error.detailed to True.

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -429,7 +429,7 @@ registerChannelValue(supybot.reply, 'whenNotCommand',
 
 registerGroup(supybot.reply, 'error')
 registerGlobalValue(supybot.reply.error, 'detailed',
-    registry.Boolean(False, _("""Determines whether error messages that result
+    registry.Boolean(True, _("""Determines whether error messages that result
     from bugs in the bot will show a detailed error message (the uncaught
     exception) or a generic error message.""")))
 registerChannelValue(supybot.reply.error, 'inPrivate',


### PR DESCRIPTION
Most of people are just pasting the `An error has occurred and has been logged. Check the logs for more informations.` message without even looking at the logs and they are then told to set this as True.

If this defaulted to True, we would probably tell them to look at messages.log anyway, but this might help. Any opinions?
