### PR TITLE
Fix #672 (?)

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -693,7 +693,7 @@ registerGroup(supybot.commands, 'defaultPlugins',
     commands."""))
 registerGlobalValue(supybot.commands.defaultPlugins, 'importantPlugins',
     registry.SpaceSeparatedSetOfStrings(
-        ['Admin', 'Channel', 'Config', 'Misc', 'Owner', 'Plugin', 'User'],
+        ['Admin', 'Channel', 'Config', 'Later', 'Misc', 'Owner', 'Plugin', 'User'],
         _("""Determines what plugins automatically get precedence over all
         other plugins when selecting a default plugin for a command.  By
         default, this includes the standard loaded plugins.  You probably


### PR DESCRIPTION
Add Later to supybot.commands.defaultPlugins.

Some concerns:
- This makes Later to be always loaded, doesn't this?
- Is Later really enough important to be always loaded?
  - Most of people are usually loading it.
- If Later is important plugin, aren't some others than these too?
  - Ctcp, Google, Web, NickCapture, Seen, Time, Topic?
- Will this make Limnoria bloated?

**Comments wanted!**
