### PR TITLE
Change default topic separator to a single pipe

### DIFF
--- a/plugins/Topic/config.py
+++ b/plugins/Topic/config.py
@@ -47,7 +47,7 @@ class TopicFormat(registry.TemplatedString):
 
 Topic = conf.registerPlugin('Topic')
 conf.registerChannelValue(Topic, 'separator',
-    registry.StringSurroundedBySpaces(' || ', _("""Determines what separator is
+    registry.StringSurroundedBySpaces(' | ', _("""Determines what separator is
     used between individually added topics in the channel topic.""")))
 conf.registerChannelValue(Topic, 'format',
     TopicFormat('$topic ($nick)', _("""Determines what format is used to add

--- a/plugins/Topic/test.py
+++ b/plugins/Topic/test.py
@@ -69,7 +69,7 @@ class TopicTestCase(ChannelPluginTestCase):
         m = self.getMsg('topic add bar')
         self.assertEqual(m.command, 'TOPIC')
         self.assertEqual(m.args[0], self.channel)
-        self.assertEqual(m.args[1], 'foo (test) || bar (test)')
+        self.assertEqual(m.args[1], 'foo (test) | bar (test)')
 
     def testManageCapabilities(self):
         try:
@@ -95,7 +95,7 @@ class TopicTestCase(ChannelPluginTestCase):
         m = self.getMsg('topic add foo')
         self.assertEqual(m.args[1], 'foo (test)')
         m = self.getMsg('topic insert bar')
-        self.assertEqual(m.args[1], 'bar (test) || foo (test)')
+        self.assertEqual(m.args[1], 'bar (test) | foo (test)')
 
     def testChange(self):
         _ = self.getMsg('topic add foo')
@@ -168,9 +168,9 @@ class TopicTestCase(ChannelPluginTestCase):
             conf.supybot.plugins.Topic.format.setValue('$topic')
             self.assertResponse('topic set ""', '')
             self.assertResponse('topic add foo', 'foo')
-            self.assertResponse('topic add bar', 'foo || bar')
-            self.assertResponse('topic add baz', 'foo || bar || baz')
-            self.assertResponse('topic undo', 'foo || bar')
+            self.assertResponse('topic add bar', 'foo | bar')
+            self.assertResponse('topic add baz', 'foo | bar | baz')
+            self.assertResponse('topic undo', 'foo | bar')
             self.assertResponse('topic undo', 'foo')
             self.assertResponse('topic undo', '')
         finally:
@@ -182,19 +182,19 @@ class TopicTestCase(ChannelPluginTestCase):
             conf.supybot.plugins.Topic.format.setValue('$topic')
             self.assertResponse('topic set ""', '')
             self.assertResponse('topic add foo', 'foo')
-            self.assertResponse('topic add bar', 'foo || bar')
-            self.assertResponse('topic add baz', 'foo || bar || baz')
-            self.assertResponse('topic undo', 'foo || bar')
+            self.assertResponse('topic add bar', 'foo | bar')
+            self.assertResponse('topic add baz', 'foo | bar | baz')
+            self.assertResponse('topic undo', 'foo | bar')
             self.assertResponse('topic undo', 'foo')
             self.assertResponse('topic undo', '')
             self.assertResponse('topic redo', 'foo')
-            self.assertResponse('topic redo', 'foo || bar')
-            self.assertResponse('topic redo', 'foo || bar || baz')
-            self.assertResponse('topic undo', 'foo || bar')
+            self.assertResponse('topic redo', 'foo | bar')
+            self.assertResponse('topic redo', 'foo | bar | baz')
+            self.assertResponse('topic undo', 'foo | bar')
             self.assertResponse('topic undo', 'foo')
-            self.assertResponse('topic redo', 'foo || bar')
+            self.assertResponse('topic redo', 'foo | bar')
             self.assertResponse('topic undo', 'foo')
-            self.assertResponse('topic redo', 'foo || bar')
+            self.assertResponse('topic redo', 'foo | bar')
         finally:
             conf.supybot.plugins.Topic.format.setValue(original)
 
@@ -204,10 +204,10 @@ class TopicTestCase(ChannelPluginTestCase):
             conf.supybot.plugins.Topic.format.setValue('$topic')
             self.assertResponse('topic set ""', '')
             self.assertResponse('topic add foo', 'foo')
-            self.assertResponse('topic add bar', 'foo || bar')
-            self.assertResponse('topic add baz', 'foo || bar || baz')
-            self.assertResponse('topic swap 1 2', 'bar || foo || baz')
-            self.assertResponse('topic swap 1 -1', 'baz || foo || bar')
+            self.assertResponse('topic add bar', 'foo | bar')
+            self.assertResponse('topic add baz', 'foo | bar | baz')
+            self.assertResponse('topic swap 1 2', 'bar | foo | baz')
+            self.assertResponse('topic swap 1 -1', 'baz | foo | bar')
             self.assertError('topic swap -1 -1')
             self.assertError('topic swap 2 -2')
             self.assertError('topic swap 1 -3')
@@ -232,8 +232,8 @@ class TopicTestCase(ChannelPluginTestCase):
             conf.supybot.plugins.Topic.format.setValue('$topic')
             self.assertError('topic addd') # Error to send too many args.
             self.assertResponse('topic add foo', 'foo')
-            self.assertResponse('topic add bar', 'foo || bar')
-            self.assertResponse('topic', 'foo || bar')
+            self.assertResponse('topic add bar', 'foo | bar')
+            self.assertResponse('topic', 'foo | bar')
         finally:
             conf.supybot.plugins.Topic.format.setValue(original)
 
@@ -242,11 +242,11 @@ class TopicTestCase(ChannelPluginTestCase):
         try:
             conf.supybot.plugins.Topic.format.setValue('$topic')
             self.assertResponse('topic add foo', 'foo')
-            self.assertResponse('topic add bar', 'foo || bar')
-            self.assertResponse('topic add baz', 'foo || bar || baz')
-            self.assertResponse('topic separator |', 'foo | bar | baz')
+            self.assertResponse('topic add bar', 'foo | bar')
+            self.assertResponse('topic add baz', 'foo | bar | baz')
             self.assertResponse('topic separator ::', 'foo :: bar :: baz')
             self.assertResponse('topic separator ||', 'foo || bar || baz')
+            self.assertResponse('topic separator |', 'foo | bar | baz')
         finally:
             conf.supybot.plugins.Topic.format.setValue(original)
 
@@ -256,9 +256,9 @@ class TopicTestCase(ChannelPluginTestCase):
             conf.supybot.plugins.Topic.format.setValue('$topic')
             self.irc.state.supported['TOPICLEN'] = 20
             self.assertResponse('topic fit foo', 'foo')
-            self.assertResponse('topic fit bar', 'foo || bar')
-            self.assertResponse('topic fit baz', 'foo || bar || baz')
-            self.assertResponse('topic fit qux', 'bar || baz || qux')
+            self.assertResponse('topic fit bar', 'foo | bar')
+            self.assertResponse('topic fit baz', 'foo | bar | baz')
+            self.assertResponse('topic fit qux', 'bar | baz | qux')
         finally:
             conf.supybot.plugins.Topic.format.setValue(original)
             self.irc.state.supported.pop('TOPICLEN', None)


### PR DESCRIPTION
I see a single pipe used to separate topics much more frequently than double pipes.
