### PR TITLE
Can we stop officially supporting Windows, please?

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -272,8 +272,6 @@
 	* Fixed Alias.lock and Alias.unlock to work properly now that the
 	alias functions are no longer attributes of the Alias plugin.
 
-	* Fixed a Windows-specific NameError in log.py.
-
 	* Fixed Config.help to actually perform the string substitution of the
 	given config name.
 
@@ -973,10 +971,6 @@
 	* Fixed an exception in RSS.getHeadlines.
 
 	* Fixed a couple bugs in Poll, when retrieving the Poll id.
-
-	* Fixed a problem with trying to use socket.inet_pton under
-	Windows; Python doesn't build their Win32 port with IPV6 support,
-	so we have to brute-force IPV6 detection.
 
 	* Fixed a few bugs with how Infobot handled the SQLite db.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -178,39 +178,3 @@ rm -rf build/
 rm /usr/local/bin/supybot*
 rm ~/.local/bin/supybot*
 ```
-
-## Windows
-
-**Note**: If you are using an IPV6 connection, you will not be able
-to run Supybot under Windows (unless Python has fixed things).  Current
-versions of Python for Windows are *not* built with IPV6 support. This
-isn't expected to be fixed until Python 2.4, at the earliest.
-
-Now that you have Python installed, open up a command prompt.  The
-easiest way to do this is to open the run dialog (Programs -> run) and
-type "cmd" (for Windows 2000/XP/2003) or "command" (for Windows 9x).  In
-order to reduce the amount of typing you need to do, I suggest adding
-Python's directory to your path.  If you installed Python using the
-default settings, you would then do the following in the command prompt
-(otherwise change the path to match your settings)::
-
-```
-set PATH=C:\Python2x\;%PATH%
-```
-
-You should now be able to type 'python' to start the Python
-interpreter.  Exit by pressing CTRL-Z and then Return.  Now that that's
-setup, you'll want to cd into the directory that was created when you
-unzipped Supybot; I'll assume you unzipped it to 'C:\Supybot' for these
-instructions.  From 'C:\Supybot', run 
-
-```
-python setup.py install
-```
-
-This will install Supybot under 'C:\Python2x\'.  You will now have several new
-programs installed in 'C:\Python2x\Scripts\'.  The two that might be of
-particular interest to you, the new user, are 'supybot' and 'supybot-wizard'.
-The former, 'supybot', is the script to run an actual bot; the latter,
-'supybot-wizard', is an in-depth wizard that provides a nice user interface for
-creating a registry file for your bot.

--- a/setup.py
+++ b/setup.py
@@ -234,7 +234,6 @@ setup(
         'Natural Language :: Italian',
         'Operating System :: OS Independent',
         'Operating System :: POSIX',
-        'Operating System :: Microsoft :: Windows',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.2',


### PR DESCRIPTION
Windows is the source of most of issues that are encountered with all Supybot forks and the Windows part is the part of documentation with the lowest updating.

This pull request removes the references to Windows in the root directory. 
