### PR TITLE
src/conf.py: use ISO 8601 in reply.format.time.

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -367,7 +367,7 @@ registerGroup(supybot.reply, 'format')
 registerChannelValue(supybot.reply.format, 'url',
     registry.String('<%s>', _("""Determines how urls should be formatted.""")))
 registerChannelValue(supybot.reply.format, 'time',
-    registry.String('%I:%M %p, %B %d, %Y', _("""Determines how timestamps
+    registry.String('%Y-%m-%d %H:%M:%S%z', _("""Determines how timestamps
     printed for human reading should be formatted. Refer to the Python
     documentation for the time module to see valid formatting characters for
     time formats.""")))


### PR DESCRIPTION
If I read the code for Time correctly, it uses this value by default. I think that this fixes #701 .
