### PR TITLE
ChannelLogger: set FlushImmediately to True.

### DIFF
--- a/plugins/ChannelLogger/config.py
+++ b/plugins/ChannelLogger/config.py
@@ -45,7 +45,7 @@ ChannelLogger = conf.registerPlugin('ChannelLogger')
 conf.registerChannelValue(ChannelLogger, 'enable',
     registry.Boolean(True, _("""Determines whether logging is enabled.""")))
 conf.registerGlobalValue(ChannelLogger, 'flushImmediately',
-    registry.Boolean(False, _("""Determines whether channel logfiles will be
+    registry.Boolean(True, _("""Determines whether channel logfiles will be
     flushed anytime they're written to, rather than being buffered by the
     operating system.""")))
 conf.registerChannelValue(ChannelLogger, 'showJoinParts',


### PR DESCRIPTION
- This is default behaviour with ZNC and some other IRC related applications.
- Users are often confused when the logs don't appear.
- The logs will less likely get lost if they are written immediately.
- Gribble is doing this too (but not by default).
