### PR TITLE
Relay: set NoticeNonPrivmsgs to True.

### DIFF
--- a/plugins/Relay/config.py
+++ b/plugins/Relay/config.py
@@ -83,7 +83,7 @@ conf.registerChannelValue(Relay, 'ignores',
     Ignores([], _("""Determines what hostmasks will not be relayed on a
     channel.""")))
 conf.registerChannelValue(Relay, 'noticeNonPrivmsgs',
-    registry.Boolean(False, _("""Determines whether the bot will used NOTICEs
+    registry.Boolean(True, _("""Determines whether the bot will used NOTICEs
     rather than PRIVMSGs for non-PRIVMSG relay messages (i.e., joins, parts,
     nicks, quits, modes, etc.)""")))
 


### PR DESCRIPTION
Please see https://github.com/TkTech/notifico/issues/79
- > There is a difference between a NOTICE to a channel and a NOTICE to a user, every client should be able to correctly display notices to a channel. ~~ @Dav1dde
- > They should, but they don't. ~~ @Mkaysi
- > That's besides the point. There are a lot of clients that do handle it properly, and if they don't then that's not notifico's fault, that's their own fault. ~~ @sckasturi
