### PR TITLE
src/conf.py: Add AutoMode to importantplugins

### DIFF
--- a/scripts/supybot-wizard
+++ b/scripts/supybot-wizard
@@ -688,6 +688,7 @@ def main():
 
     # Let's make sure that src/ plugins are loaded.
     conf.registerPlugin('Admin', True)
+    conf.registerPlugin('AutoMode', True)
     conf.registerPlugin('Channel', True)
     conf.registerPlugin('Config', True)
     conf.registerPlugin('Misc', True)


### PR DESCRIPTION
- AutoMode is required by some features of Channel.
  - `ban *`

If we don't want AutoMode to be important plugin, the `channel ban *` commands should be made to not depend on AutoMode.
