### PR TITLE
Add manual pages for Limnoria* commands as we already have the commands.

### DIFF
--- a/docs/man/limnoria-adduser.1
+++ b/docs/man/limnoria-adduser.1
@@ -1,0 +1,1 @@
+supybot-adduser.1

--- a/docs/man/limnoria-botchk.1
+++ b/docs/man/limnoria-botchk.1
@@ -1,0 +1,1 @@
+supybot-botchk.1

--- a/docs/man/limnoria-plugin-create.1
+++ b/docs/man/limnoria-plugin-create.1
@@ -1,0 +1,1 @@
+supybot-plugin-create.1

--- a/docs/man/limnoria-plugin-doc.1
+++ b/docs/man/limnoria-plugin-doc.1
@@ -1,0 +1,1 @@
+supybot-plugin-doc.1

--- a/docs/man/limnoria-test.1
+++ b/docs/man/limnoria-test.1
@@ -1,0 +1,1 @@
+supybot-test.1

--- a/docs/man/limnoria-wizard.1
+++ b/docs/man/limnoria-wizard.1
@@ -1,0 +1,1 @@
+supybot-wizard.1

--- a/docs/man/limnoria.1
+++ b/docs/man/limnoria.1
@@ -1,0 +1,1 @@
+supybot.1

--- a/setup.py
+++ b/setup.py
@@ -272,6 +272,13 @@ setup(
                 ('share/man/man1', ['docs/man/supybot-adduser.1']),
                 ('share/man/man1', ['docs/man/supybot-plugin-doc.1']),
                 ('share/man/man1', ['docs/man/supybot-plugin-create.1']),
+                ('share/man/man1', ['docs/man/limnoria.1']),
+                ('share/man/man1', ['docs/man/limnoria-test.1']),
+                ('share/man/man1', ['docs/man/limnoria-botchk.1']),
+                ('share/man/man1', ['docs/man/limnoria-wizard.1']),
+                ('share/man/man1', ['docs/man/limnoria-adduser.1']),
+                ('share/man/man1', ['docs/man/limnoria-plugin-doc.1']),
+                ('share/man/man1', ['docs/man/limnoria-plugin-create.1']),
         ]
     )
 


### PR DESCRIPTION
Squashed commit of the following:

commit 7397647f7f5c44a9e883b500b9342936c14c0188
Author: Mikaela Suomalainen mikaela.suomalainen@outlook.com
Date:   Tue Jun 3 16:23:30 2014 +0300

```
setup.py: add missing ".1"s.
```

commit f9a95ebb4900a4b13b0f69fc674d4e9a7f7b019b
Author: Mikaela Suomalainen mikaela.suomalainen@outlook.com
Date:   Tue Jun 3 16:22:17 2014 +0300

```
fix c48e9f087daf7c69eca8c01c4e52b5843039a119

Limnoria, not Limnotia!
```

commit 467480325a4b6e90ac10875316867d9a218a4bc6
Author: Mikaela Suomalainen mikaela.suomalainen@outlook.com
Date:   Tue Jun 3 16:16:14 2014 +0300

```
Add manual pages for limnoria*

We already have binaries with name limnoria*, so it makes sense to also
have manual pages.
```
