### PR TITLE
Karma: fix quoting in README.md and one mistake.

### DIFF
--- a/plugins/Karma/README.md
+++ b/plugins/Karma/README.md
@@ -1,7 +1,7 @@
 This will increase or decrease karma for the item.
 
-If "config plugins.karma.allowUnaddressedKarma" is set to true (default since 2014.05.07), saying "boats++" will give 1 karma to "boats", and "ships--" will subtract 1 karma from "ships".
+If `config plugins.karma.allowUnaddressedKarma` is set to `True` (default since 2014.05.07), saying `boats++` will give 1 karma to `boats`, and `ships--` will subtract 1 karma from `ships`.
 
-However, if you use this in a sentence, like "That deserves a ++. Kevin++", 1 karma will be added to "That deserves a ++. Kevin", so you should only add or subtract karma in a line that doesn't have anything else in it.
+However, if you use this in a sentence, like `That deserves a ++. Kevin++`, 1 karma will be added to `That deserves a ++. Kevin`, so you should only add or subtract karma in a line that doesn't have anything else in it.
 
-If "config plugins.karma.allowUnaddressedKarma" is set to false, you must use "botname: bots++" to add or subtract karma.
+If `config plugins.karma.allowUnaddressedKarma` is set to `False`, you must address the bot with nick or prefix to add or subtract karma.


### PR DESCRIPTION
- plugins.karma.allowunaddressedkarma doesn't mean that the bot must be addressed by nick. It must be addressed, but that can also happen with prefix.

[SKIP CI]
