### PR TITLE
.travis.runonce.bash: remove broken if

### DIFF
--- a/.travis.runonce.bash
+++ b/.travis.runonce.bash
@@ -16,8 +16,8 @@ fi
 # Check translations
 sandbox/check_trans.py plugins/
 sandbox/check_trans.py --core
-msgcheck locales/*.po --no-lines
-msgcheck plugins/*/*/*.po --no-lines
+msgcheck -flwW locales/*.po
+msgcheck -flwW plugins/*/*/*.po
 
 # Check documentation
 cd docs


### PR DESCRIPTION
```
+echo '(detached from 8d70cf1) is not master nor testing, doing
nothing.'
(detached from 8d70cf1) is not master nor testing, doing nothing.
```
