### PR TITLE
fix .travis.runonce.bash

### DIFF
--- a/.travis.runonce.bash
+++ b/.travis.runonce.bash
@@ -16,8 +16,8 @@ fi
 # Check translations
 sandbox/check_trans.py plugins/
 sandbox/check_trans.py --core
-msgcheck locales/*.po
-msgcheck plugins/*/*/*.po
+msgcheck -flwW locales/*.po
+msgcheck -flwW plugins/*/*/*.po
 
 # Check documentation
 cd docs
@@ -25,11 +25,5 @@ cd docs
 sphinx-build -n -b html -d _build/doctrees . _build/html
 cd ..
 
-# Do these things only on testing or master.
-if [[ "$branch" = "master" || "$branch" = "testing" ]]; then
-    # Notify read the docs
-    curl -X POST http://readthedocs.org/build/limnoria
-    # Add other things which we want to do here, before the fi.
-else
-    echo "$branch is not master nor testing, doing nothing."
-fi
+# Notify read the docs
+curl -X POST http://readthedocs.org/build/limnoria


### PR DESCRIPTION
- msgcheck now doesn't cause false-alarms with Limnoria specific things.
- remove the broken if which never gets executed by Travis
- These commits have already been build invidually so [SKIP CI]
