### PR TITLE
Ctcp: fix README.md

### DIFF
--- a/plugins/Ctcp/README.md
+++ b/plugins/Ctcp/README.md
@@ -1,5 +1,5 @@
-This plugin gives command ´@ctcp version´ which returns all CTCP version responses to channel.
+This plugin gives command `ctcp version` which returns all CTCP version responses to channel.
 It also adds CTCP responses to the bot.
 
-Please note that the command `@ctcp version´ cannot receive any responses if the channel is 
+Please note that the command `ctcp version` cannot receive any responses if the channel is 
 mode +C or similar which prevents CTCP requests to channel.


### PR DESCRIPTION
- Fix quoting
- Remove prefix, quoting should tell that it's a bot command

[SKIP CI]
