### PR TITLE
.travis.yml: enable fast-finish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,5 @@ after_success:
 notifications:
     on_success: never
     on_failure: never
+matrix:
+  fast_finish: true


### PR DESCRIPTION
If I understand correctly, this makes the build fail when one build fails without having to wait for all builds to finish.

This might abort building for those which haven't finished yet, but we probably want to know that build fails as soon as one build fails.
