### PR TITLE
fix .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ script:
 after_success:
     - if [ "$TRAVIS_PYTHON_VERSION" = "3.4" ]; then bash .travis.runonce.bash;fi
 notifications:
-    on_success: never
-    on_failure: never
+    email: false
 matrix:
   fast_finish: true


### PR DESCRIPTION
before

```
% travis lint .travis.yml
Warnings for .travis.yml:
[x] value for notifications section is empty, dropping
[x] in notifications section: unexpected key on_success, dropping
[x] in notifications section: unexpected key on_failure, dropping
```

now:

```
Hooray, .travis.yml looks valid :)
```

See also ProgVal/Supybot-plugins#217
