### PR TITLE
RSS: remove announcementPrefix

### DIFF
--- a/plugins/RSS/config.py
+++ b/plugins/RSS/config.py
@@ -57,7 +57,7 @@ conf.registerChannelValue(RSS, 'headlineSeparator',
     registry.StringSurroundedBySpaces('|', _("""Determines what string is
     used to separate headlines in new feeds.""")))
 conf.registerChannelValue(RSS, 'announcementPrefix',
-    registry.StringWithSpaceOnRight(_('News from '), _("""Determines what
+    registry.StringWithSpaceOnRight(_(''), _("""Determines what
     prefix is prepended (if any) to the news item announcements made in the
     channel.""")))
 conf.registerChannelValue(RSS, 'announcementSeparator',

--- a/plugins/RSS/locales/fi.po
+++ b/plugins/RSS/locales/fi.po
@@ -1,12 +1,12 @@
 # RSS plugin in Limnoria.
-# Copyright (C) Limnoria 2011
-# Mikaela Suomalainen <mkaysi@outlook.com>, 2011, 2012.
+# Copyright (C) Limnoria 2011-2014
+# Mikaela Suomalainen <mkaysi@outlook.com>, 2011-2014.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2014-05-31 15:04+EEST\n"
-"PO-Revision-Date: 2014-05-31 15:10+0200\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: 2014-07-21 08:36+0200\n"
 "Last-Translator: Mikaela Suomalainen <mikaela.suomalainen@outlook.com>\n"
 "Language-Team: Finnish <>\n"
 "Language: fi\n"
@@ -45,10 +45,6 @@ msgid ""
 msgstr ""
 "Määrittää kanavalla tehtyihin uutiskuulutuksiin liitettävän etuliitteen (jos "
 "mikään)."
-
-#: config.py:60
-msgid "News from "
-msgstr "Uutisia kohteesta "
 
 #: config.py:64
 msgid ": "
@@ -319,3 +315,6 @@ msgstr "En voinut noutaa tuota RSS syötettä."
 #: plugin.py:518
 msgid "Title: %s;  URL: %u;  Description: %s;  Last updated: %s."
 msgstr "Otsikko: %s;  URL: %u;  Kuvaus: %s;  Viimeeksi päivitetty: %s."
+
+#~ msgid "News from "
+#~ msgstr "Uutisia kohteesta "

--- a/plugins/RSS/messages.pot
+++ b/plugins/RSS/messages.pot
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2014-03-22 16:34+EET\n"
+"POT-Creation-Date: 2014-07-21 08:35+EEST\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -34,13 +34,13 @@ msgstr ""
 
 #: config.py:60
 msgid ""
-"Determines what\n"
-"    prefix is prepended (if any) to the news item announcements made in the\n"
-"    channel."
 msgstr ""
 
 #: config.py:60
-msgid "News from "
+msgid ""
+"Determines what\n"
+"    prefix is prepended (if any) to the news item announcements made in the\n"
+"    channel."
 msgstr ""
 
 #: config.py:64


### PR DESCRIPTION
AnnouncementPrefix often looks bad with different feeds ( #104 ) and
takes more important space from titles or links ( #790 ).
(Since when webcomics or commit messages or issue titles have been news?)

I also believe that the announcementPrefix should be added by user if
they want it as they will probably know better what kind of feeds they
have and what is correct prefix for them.
