### PR TITLE
ShrinkUrl: enable outfilter by default

### DIFF
--- a/plugins/ShrinkUrl/config.py
+++ b/plugins/ShrinkUrl/config.py
@@ -84,7 +84,7 @@ conf.registerChannelValue(ShrinkUrl, 'nonSnarfingRegexp',
     matching the regexp given will not be snarfed.  Give the empty string if
     you have no URLs that you'd like to exclude from being snarfed.""")))
 conf.registerChannelValue(ShrinkUrl, 'outFilter',
-    registry.Boolean(False, _("""Determines whether the bot will shrink the
+    registry.Boolean(True, _("""Determines whether the bot will shrink the
     URLs of outgoing messages if those URLs are longer than
     supybot.plugins.ShrinkUrl.minimumLength.""")))
 conf.registerChannelValue(ShrinkUrl, 'default',


### PR DESCRIPTION
The ShrinkUrl outfilter shrinks the URLs that are over chars specified by `supybot.plugins.shrinkurl.minimumlength`. It defaults to 48.

This is useful with RSS and I think that this feature is reason why many people load this plugin.
