### PR TITLE
Channel: Let owner see nicks in a private channel

### DIFF
--- a/plugins/Channel/plugin.py
+++ b/plugins/Channel/plugin.py
@@ -886,6 +886,7 @@ class Channel(callbacks.Plugin):
         # Make sure we don't elicit information about private channels to
         # people or channels that shouldn't know
         if 's' in irc.state.channels[channel].modes and \
+            not ircdb.checkCapability(msg.nick, 'owner') and \
             msg.args[0] != channel and \
             (ircutils.isChannel(msg.args[0]) or \
              msg.nick not in irc.state.channels[channel].users):


### PR DESCRIPTION
The bot owner(s) are not able to issue the `nicks`-command of the Channel-plugin if the addressed channel is secret.
I believe the owner should be able to get this information, given they could join the channel anyway, but if the current behavior is the expected one, feel free to close the request.

(I hope I did this correctly, first time messing with Limnoria/Supybot.)
