### PR TITLE
src/conf.py: make help text for defaultignore...

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -1170,9 +1170,9 @@ registerGlobalValue(supybot.servers.http, 'favicon',
 ###
 registerGlobalValue(supybot, 'defaultIgnore',
     registry.Boolean(False, _("""Determines whether the bot will ignore
-    unregistered users by default.  Of course, that'll make it particularly
-    hard for those users to register or identify with the bot, but that's your
-    problem to solve.""")))
+    unidentified users by default.  Of course, that'll make it
+    particularly hard for those users to register or identify with the bot
+    without adding their hostmasks, but that's your problem to solve.""")))
 
 
 registerGlobalValue(supybot, 'externalIP',


### PR DESCRIPTION
more clear

Now the help text says `unidentified` instead of `unregistered` and
hostmasks are mentioned.
