### PR TITLE
Unix: add ping6 (closes #821)

### DIFF
--- a/plugins/Unix/config.py
+++ b/plugins/Unix/config.py
@@ -95,6 +95,11 @@ conf.registerGlobalValue(Unix.ping, 'command',
     registry.String(utils.findBinaryInPath('ping') or '', """Determines what 
     command will be called for the ping command."""))
 
+conf.registerGroup(Unix, 'ping6')
+conf.registerGlobalValue(Unix.ping6, 'command', 
+    registry.String(utils.findBinaryInPath('ping6') or '', """Determines what 
+    command will be called for the ping6 command."""))
+
 conf.registerGroup(Unix, 'sysuptime')
 conf.registerGlobalValue(Unix.sysuptime, 'command',
     registry.String(utils.findBinaryInPath('uptime') or '', """Determines what

--- a/plugins/Unix/locales/fi.po
+++ b/plugins/Unix/locales/fi.po
@@ -5,8 +5,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2014-03-22 12:07+EET\n"
-"PO-Revision-Date: 2014-03-22 12:20+0200\n"
+"POT-Creation-Date: 2014-08-24 17:43+EEST\n"
+"PO-Revision-Date: 2014-08-24 17:45+0200\n"
 "Last-Translator: Mikaela Suomalainen <mikaela.suomalainen@outlook.com>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -311,7 +311,26 @@ msgstr ""
 "        tai vähempään. --W on rajoitettu kymmeneen tai vähempään.\n"
 "        "
 
-#: plugin.py:322
+#: plugin.py:324
+msgid ""
+"[--c <count>] [--i <interval>] [--t <ttl>] [--W <timeout>] <host or ip>\n"
+"        Sends an ICMP echo request to the specified host.\n"
+"        The arguments correspond with those listed in ping6(8). --c is\n"
+"        limited to 10 packets or less (default is 5). --i is limited to 5\n"
+"        or less. --W is limited to 10 or less.\n"
+"        "
+msgstr ""
+"[--c <määrä>] [--i <kesto>] [--t <ttl>] [--W <aikakatkaisu>] <isäntä tai "
+"ip>\n"
+"        Lähettää ICMP kaiutuspyynnön määritettyyn isäntään.\n"
+"        Parametrin täsmäävät niihin, jotka on määritetty ohjekirjasivulla "
+"ping(8). --c on\n"
+"        rajoitettu kymmeneen tai vähempään (oletus on 5). --i on rajoitettu "
+"viiteen\n"
+"        tai vähempään. --W on rajoitettu kymmeneen tai vähempään.\n"
+"        "
+
+#: plugin.py:378
 msgid ""
 "takes no arguments\n"
 "\n"
@@ -322,7 +341,7 @@ msgstr ""
 "        Palauttaa järjestelmän, jolla botti on ylläoloajan.\n"
 "        "
 
-#: plugin.py:351
+#: plugin.py:407
 msgid ""
 "takes no arguments\n"
 "\n"
@@ -335,7 +354,7 @@ msgstr ""
 "on.\n"
 "        "
 
-#: plugin.py:380
+#: plugin.py:436
 msgid ""
 "<command to call with any arguments>\n"
 "        Calls any command available on the system, and returns its output.\n"
@@ -357,7 +376,7 @@ msgstr ""
 "laittaa koneesi polvilleen. \n"
 "        "
 
-#: plugin.py:408
+#: plugin.py:464
 msgid ""
 "<command to call with any arguments>\n"
 "        Calls any command available on the system using the shell\n"

--- a/plugins/Unix/messages.pot
+++ b/plugins/Unix/messages.pot
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2014-03-22 16:34+EET\n"
+"POT-Creation-Date: 2014-08-24 17:43+EEST\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -217,7 +217,18 @@ msgid ""
 "        "
 msgstr ""
 
-#: plugin.py:322
+#: plugin.py:324
+#, docstring
+msgid ""
+"[--c <count>] [--i <interval>] [--t <ttl>] [--W <timeout>] <host or ip>\n"
+"        Sends an ICMP echo request to the specified host.\n"
+"        The arguments correspond with those listed in ping6(8). --c is\n"
+"        limited to 10 packets or less (default is 5). --i is limited to 5\n"
+"        or less. --W is limited to 10 or less.\n"
+"        "
+msgstr ""
+
+#: plugin.py:378
 #, docstring
 msgid ""
 "takes no arguments\n"
@@ -226,7 +237,7 @@ msgid ""
 "        "
 msgstr ""
 
-#: plugin.py:351
+#: plugin.py:407
 #, docstring
 msgid ""
 "takes no arguments\n"
@@ -235,7 +246,7 @@ msgid ""
 "        "
 msgstr ""
 
-#: plugin.py:380
+#: plugin.py:436
 #, docstring
 msgid ""
 "<command to call with any arguments>\n"
@@ -248,7 +259,7 @@ msgid ""
 "        "
 msgstr ""
 
-#: plugin.py:408
+#: plugin.py:464
 #, docstring
 msgid ""
 "<command to call with any arguments>\n"

--- a/plugins/Unix/plugin.py
+++ b/plugins/Unix/plugin.py
@@ -318,6 +318,62 @@ class Unix(callbacks.Plugin):
                                 't':'positiveInt','W':'positiveInt'}),
                        first('ip', ('matches', _hostExpr, 'Invalid hostname'))]))
 
+
+    @internationalizeDocstring
+    def ping6(self, irc, msg, args, optlist, host):
+        """[--c <count>] [--i <interval>] [--t <ttl>] [--W <timeout>] <host or ip>
+        Sends an ICMP echo request to the specified host.
+        The arguments correspond with those listed in ping6(8). --c is
+        limited to 10 packets or less (default is 5). --i is limited to 5
+        or less. --W is limited to 10 or less.
+        """
+        ping6Cmd = self.registryValue('ping6.command')
+        if not ping6Cmd:
+           irc.error('The ping6 command is not configured.  If one '
+                     'is installed, reconfigure '
+                     'supybot.plugins.Unix.ping6.command appropriately.',
+                     Raise=True)
+        else:
+            try: host = host.group(0)
+            except AttributeError: pass
+
+            args = [ping6Cmd]
+            for opt, val in optlist:
+                if opt == 'c' and val > 10: val = 10
+                if opt == 'i' and val >  5: val = 5
+                if opt == 'W' and val > 10: val = 10
+                args.append('-%s' % opt)
+                args.append(str(val))
+            if '-c' not in args:
+                args.append('-c')
+                args.append('5')
+            args.append(host)
+            try:
+                with open(os.devnull) as null:
+                    inst = subprocess.Popen(args,
+                                            stdout=subprocess.PIPE,
+                                            stderr=subprocess.PIPE,
+                                            stdin=null)
+            except OSError as e:
+                irc.error('It seems the configured ping6 command was '
+                          'not available (%s).' % e, Raise=True)
+            result = inst.communicate()
+            if result[1]: # stderr
+                irc.error(' '.join(result[1].decode('utf8').split()))
+            else:
+                response = result[0].decode('utf8').split("\n");
+                if response[1]:
+                    irc.reply(' '.join(response[1].split()[3:5]).split(':')[0]
+                              + ': ' + ' '.join(response[-3:]))
+                else:
+                    irc.reply(' '.join(response[0].split()[1:3])
+                              + ': ' + ' '.join(response[-3:]))
+
+    _hostExpr = re.compile(r'^[a-z0-9][a-z0-9\.-]*[a-z0-9]$', re.I)
+    ping6 = thread(wrap(ping6, [getopts({'c':'positiveInt','i':'float',
+                                't':'positiveInt','W':'positiveInt'}),
+                       first('ip', ('matches', _hostExpr, 'Invalid hostname'))]))
+
     def sysuptime(self, irc, msg, args):
         """takes no arguments
 

--- a/plugins/Unix/test.py
+++ b/plugins/Unix/test.py
@@ -88,6 +88,29 @@ if os.name == 'posix':
                 self.assertNotError('unix ping --W 1 --c 1 127.0.0.1')
                 self.assertError('unix ping --W a --c 1 127.0.0.1')
 
+        if utils.findBinaryInPath('ping6') is not None:
+            def testPing6(self):
+                self.assertNotError('unix ping6 ::1')
+                self.assertError('unix ping6')
+                self.assertError('unix ping6 -localhost')
+                self.assertError('unix ping6 local%host')
+            def testPing6Count(self):
+                self.assertNotError('unix ping6 --c 1 ::1')
+                self.assertError('unix ping6 --c a ::1')
+                self.assertRegexp('unix ping6 --c 11 ::1','10 packets')
+                self.assertRegexp('unix ping6 ::1','5 packets')
+            def testPing6Interval(self):
+                self.assertNotError('unix ping6 --i 1 --c 1 ::1')
+                self.assertError('unix ping6 --i a --c 1 ::1')
+                # Super-user privileged interval setting
+                self.assertError('unix ping6 --i 0.1 --c 1 ::1') 
+            def testPing6Ttl(self):
+                self.assertNotError('unix ping6 --t 64 --c 1 ::1')
+                self.assertError('unix ping6 --t a --c 1 ::1')
+            def testPing6Wait(self):
+                self.assertNotError('unix ping6 --W 1 --c 1 ::1')
+                self.assertError('unix ping6 --W a --c 1 ::1')
+
         def testCall(self):
             self.assertNotError('unix call /bin/ping -c 1 localhost')
             self.assertRegexp('unix call /bin/ping -c 1 localhost', 'ping statistics')


### PR DESCRIPTION
I simply copy-pasted everything and changed `ping` to `ping6` and replaced `127.0.0.1` with `::1`.

The separate commits are in my `unix` branch in case they are needed before this is merged.

Tests passed on localhost and I tested that this worked with Tessu.

```
2014-08-24 17:42:21+0300 <@Mikaela> %reload Unix
2014-08-24 17:42:22+0300 -- Notice(Tessu): OK!
2014-08-24 17:42:26+0300 <@Mikaela> %list unix
2014-08-24 17:42:29+0300 -- Notice(Tessu): call, crypt, errno, fortune, pid, ping, ping6, progstats, shell, spell, sysuname, sysuptime, ja wtf
2014-08-24 17:42:34+0300 <@Mikaela> %help ping6
2014-08-24 17:42:37+0300 -- Notice(Tessu): (ping6 [--c <count>] [--i <interval>] [--t <ttl>] [--W <timeout>] <host or ip>) -- Sends an ICMP echo request to the specified host. The arguments correspond with those listed in ping6(8). --c is limited to 10 packets or less (default is 5). --i is limited to 5 or less. --W is limited to 10 or less. 
2014-08-24 17:42:51+0300 <@Mikaela> %unix ping6 ::1
2014-08-24 17:42:56+0300 -- Notice(Tessu): : 5 packets transmitted, 5 received, 0% packet loss, time 4013ms rtt min/avg/max/mdev = 0.045/0.050/0.056/0.009 ms 
2014-08-24 17:43:03+0300 <@Mikaela> %unix ping6 ipv6.google.com
2014-08-24 17:43:10+0300 -- Notice(Tessu): arn02s06-in-x04.1e100.net: 5 packets transmitted, 5 received, 0% packet loss, time 4071ms rtt min/avg/max/mdev = 64.083/64.142/64.186/0.036 ms               
```
