### PR TITLE
Utilities.echo: follow reply.withnickprefix

### DIFF
--- a/plugins/Utilities/plugin.py
+++ b/plugins/Utilities/plugin.py
@@ -91,7 +91,7 @@ class Utilities(callbacks.Plugin):
         handled appropriately.
         """
         text = ircutils.standardSubstitute(irc, msg, text)
-        irc.reply(text, prefixNick=False)
+        irc.reply(text)
     echo = wrap(echo, ['text'])
 
     @internationalizeDocstring


### PR DESCRIPTION
In some cases, utilities.echo command not using nick prefix can be
problematic when there are other bots in channel and they are taking
commands from anyone. One example of bots like this are altcoin tipbots.

In this case there are two options: set anticapability for
utilities.echo and break many Akas/Aliases or set the bot to follow
reply.withnickprefix which feels like a good solution, but echo is
immune to it before this commit.

In case the previous method is wanted, user or channel op can set
reply.withnickprefix to False.
