### PR TITLE
Wizard: Fix creating folders in wrong dir

### DIFF
--- a/scripts/supybot-wizard
+++ b/scripts/supybot-wizard
@@ -248,6 +248,7 @@ def main():
     i18n.reloadLocales()
     import supybot.log as log
     log._stdoutHandler.setLevel(100) # *Nothing* gets through this!
+    log._handler.setLevel(100)
     import supybot.conf as conf
     i18n.import_conf() # It imports the real conf module
     import supybot.plugin as plugin

--- a/src/conf.py
+++ b/src/conf.py
@@ -772,14 +772,10 @@ registerGlobalValue(supybot.drivers, 'maxReconnectWait',
 # supybot.directories, for stuff relating to directories.
 ###
 
-# XXX This shouldn't make directories willy-nilly.  As it is now, if it's
-#     configured, it'll still make the default directories, I think.
 class Directory(registry.String):
     def __call__(self):
         # ??? Should we perhaps always return an absolute path here?
         v = super(Directory, self).__call__()
-        if not os.path.exists(v):
-            os.mkdir(v)
         return v
 
     def dirize(self, filename):


### PR DESCRIPTION
With this the log file is only created when needed, not earlier. Also no logs are made when supybot-wizard is ran.

I also removed automatic creating of all referenced dirs in conf.py. There is a *possibility* this could cause an issue but ```supybot``` always creates them on start and ```supybot-wizard``` creates them on finish. So users shouldn't be deleting random things while supybot runs.

EDIT: Ok missed a few places we still need to create folders..