### PR TITLE
Dict: use `*` as default dictionary

### DIFF
--- a/plugins/Dict/config.py
+++ b/plugins/Dict/config.py
@@ -45,8 +45,8 @@ conf.registerGlobalValue(Dict, 'server',
     registry.String('dict.org', _("""Determines what server the bot will
     retrieve definitions from.""")))
 conf.registerChannelValue(Dict, 'default',
-    registry.String('', _("""Determines the default dictionary the bot will
-    ask for definitions in.  If this value is '*' (without the quotes) the bot
-    will use all dictionaries to define words.""")))
+    registry.String('*', _("""Determines the default dictionary the bot
+    will ask for definitions in.  If this value is '*' (without the quotes)
+    the bot will use all dictionaries to define words.""")))
 
 # vim:set shiftwidth=4 softtabstop=4 expandtab textwidth=79:


### PR DESCRIPTION
The config help is unclear as it talks about `*` meaning all
dictionaries while having default value as empty string.

<hr/>

I also changed the string to fit to terminal better.
