### PR TITLE
src/conf.py: follow nick changes

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -487,10 +487,8 @@ registerChannelValue(supybot.reply, 'requireChannelCommandsToBeSentInChannel',
     itself.""")))
 
 registerGlobalValue(supybot, 'followIdentificationThroughNickChanges',
-    registry.Boolean(False, _("""Determines whether the bot will unidentify
-    someone when that person changes their nick.  Setting this to True
-    will cause the bot to track such changes.  It defaults to False for a
-    little greater security.""")))
+    registry.Boolean(True, _("""Determines whether the bot will keep users
+    identified after they have changed their nick.""")))
 
 registerChannelValue(supybot, 'alwaysJoinOnInvite',
     registry.Boolean(False, _("""Determines whether the bot will always join a


### PR DESCRIPTION
followIdentificationThroughNickChanges is now True.

I am not sure what the "little greater security" of previous `config help` meant, but False appears to make NickAuth automatically unidentify you when user changes their nick and this possibly also affects GPG.

I can see that I asked about it by grepping logs, but I cannot find answer from them as most of results come from Limnoria which is replying to `config list supybot`.

I have also seen confused users on some channels wondering about having to identify again after changing their nick.
