### PR TITLE
Topic: actually read 'requireManageCapability' per channel

### DIFF
--- a/plugins/Topic/plugin.py
+++ b/plugins/Topic/plugin.py
@@ -228,7 +228,7 @@ class Topic(callbacks.Plugin):
         c = irc.state.channels[channel]
         if msg.nick in c.ops or msg.nick in c.halfops or 't' not in c.modes:
             return True
-        capabilities = self.registryValue('requireManageCapability')
+        capabilities = self.registryValue('requireManageCapability', channel)
         if capabilities:
             for capability in re.split(r'\s*;\s*', capabilities):
                 if capability.startswith('channel,'):


### PR DESCRIPTION
Otherwise you get a capability error when a channel's configured `requireManageCapability` is less restrictive than the global one:

```
WARNING 2014-09-19T12:12:36 Denying nick!user@host for lacking
        "channel,op" capability.
```
