### PR TITLE
src/conf.py: disable strictRFC by default

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -1059,11 +1059,11 @@ registerChannelValue(supybot.protocols.irc, 'banmask',
     default banmask style.""")))
 
 registerGlobalValue(supybot.protocols.irc, 'strictRfc',
-    registry.Boolean(True, _("""Determines whether the bot will strictly follow
-    the RFC; currently this only affects what strings are considered to be
-    nicks. If you're using a server or a network that requires you to message
-    a nick such as services@this.network.server then you you should set this to
-    False.""")))
+    registry.Boolean(False, _("""Determines whether the bot will strictly
+    follow the RFC; currently this only affects what strings are
+    considered to be nicks. If you're using a server or a network that
+    requires you to message a nick such as services@this.network.server
+    then you you should set this to False.""")))
 
 registerGlobalValue(supybot.protocols.irc, 'certfile',
     registry.String('', _("""Determines what certificate file (if any) the bot


### PR DESCRIPTION
strictRFC causes issues when nicks start with numbers and on some
network this happens too often. For example, if nick isn't RFC-compliant,
the bot cannot be used to kick user from channel. Ops cannot change this
so they must op themselves and kick the user by themselves or whatever
they are going to do.

Some IRCds also allow you to change your nick to your UID using `/nick
0` and on others it happens when there is nick collision after netsplit.
