### PR TITLE
supybot-plugin-create: remove outdated reference to supybot.com

### DIFF
--- a/scripts/supybot-plugin-create
+++ b/scripts/supybot-plugin-create
@@ -170,7 +170,7 @@ __author__ = supybot.authors.unknown
 __contributors__ = {}
 
 # This is a url where the most recent plugin package can be downloaded.
-__url__ = '' # 'http://supybot.com/Members/yourname/%s/download'
+__url__ = ''
 
 from . import config
 from . import plugin


### PR DESCRIPTION
All links just give a 404 error, and the main site itself just redirects to sourceforge now.
