### PR TITLE
Remove abelist 'lithp' command from Filter plugin

### DIFF
--- a/plugins/Filter/plugin.py
+++ b/plugins/Filter/plugin.py
@@ -77,7 +77,7 @@ class Filter(callbacks.Plugin):
                     msg = ircmsgs.IrcMsg(msg=msg, args=(msg.args[0], s))
         return msg
 
-    _filterCommands = ['jeffk', 'leet', 'rot13', 'hexlify', 'binary', 'lithp',
+    _filterCommands = ['jeffk', 'leet', 'rot13', 'hexlify', 'binary',
                        'scramble', 'morse', 'reverse', 'colorize', 'squish',
                        'supa1337', 'colorstrip', 'aol', 'rainbow', 'spellit',
                        'hebrew', 'undup', 'gnu', 'shrink', 'uniud']
@@ -226,30 +226,6 @@ class Filter(callbacks.Plugin):
             text = text.decode('utf8')
         irc.reply(self._rot13_encoder(text)[0])
     rot13 = wrap(rot13, ['text'])
-
-    @internationalizeDocstring
-    def lithp(self, irc, msg, args, text):
-        """<text>
-
-        Returns the lisping version of <text>
-        """
-        text = text.replace('sh', 'th')
-        text = text.replace('SH', 'TH')
-        text = text.replace('Sh', 'Th')
-        text = text.replace('ss', 'th')
-        text = text.replace('SS', 'TH')
-        text = text.replace('s', 'th')
-        text = text.replace('z', 'th')
-        text = text.replace('S', 'Th')
-        text = text.replace('Z', 'Th')
-        text = text.replace('x', 'kth')
-        text = text.replace('X', 'KTH')
-        text = text.replace('cce', 'kth')
-        text = text.replace('CCE', 'KTH')
-        text = text.replace('tion', 'thion')
-        text = text.replace('TION', 'THION')
-        irc.reply(text)
-    lithp = wrap(lithp, ['text'])
 
     _leettrans = utils.str.MultipleReplacer(dict(list(zip('oOaAeElBTiIts',
                                                      '004433187!1+5'))))


### PR DESCRIPTION
It has been pointed out that it's quite offensive as it makes light of a defect in one's ability of communicating with others and most people that suffer from such a malady are quite sensitive about it
