### PR TITLE
supybot-wizard: load NickAuth by default

### DIFF
--- a/scripts/supybot-wizard
+++ b/scripts/supybot-wizard
@@ -693,6 +693,7 @@ def main():
     conf.registerPlugin('Channel', True)
     conf.registerPlugin('Config', True)
     conf.registerPlugin('Misc', True)
+    conf.registerPlugin('NickAuth', True)
     conf.registerPlugin('User', True)
     conf.registerPlugin('Utilities', True)
 


### PR DESCRIPTION
NickAuth functionality is often wanted by users of the bots (is the word
end-users?) and is mentioned in the documentation as method of
identifying to the bot.

I think this should be loaded by default and as this isn't
important plugin, users who don't want or need it can unload it.

One reason of wanting to unload this plugin could be serviceless
networks even if they aren't that common nowadaays.
