### PR TITLE
Owner: don't allow reloading the Owner plugin

### DIFF
--- a/plugins/Owner/plugin.py
+++ b/plugins/Owner/plugin.py
@@ -446,6 +446,9 @@ class Owner(callbacks.Plugin):
         Unloads and subsequently reloads the plugin by name; use the 'list'
         command to see a list of the currently loaded plugins.
         """
+        if ircutils.strEqual(name, self.name()):
+            irc.error('You can\'t reload the %s plugin.' % name)
+            return
         callbacks = irc.removeCallback(name)
         if callbacks:
             module = sys.modules[callbacks[0].__module__]


### PR DESCRIPTION
Currently, trying to reload the Owner plugin essentially crashes the bot (it begins ignoring all IRC input, valid or invalid). Looking at the source for the unload command however, it seems like this is not supposed to be allowed in the first place!

IRC:

```
07:40 <synnerjee> reload Owner
07:40 -- bot: uhhhhhhh... i think i derped :[
07:40 <synnerjee> a
07:40 <synnerjee> help
```

Traceback:

```
INFO 2014-11-03T07:40:30 reload called in private by
     "synnerjee!GLolol@hidden.beneath.the.plaguebox.net".
ERROR 2014-11-03T07:40:30 Spec: [<context for something>]
ERROR 2014-11-03T07:40:30 Received args: []
ERROR 2014-11-03T07:40:30 Extra args: ['name']
ERROR 2014-11-03T07:40:30 Uncaught exception in ['reload'].
Traceback (most recent call last):
  File "/home/gl/.local/lib/python3.4/site-packages/supybot/callbacks.py", line 1267, in _callCommand
    self.callCommand(command, irc, msg, *args, **kwargs)
  File "/home/gl/.local/lib/python3.4/site-packages/supybot/utils/python.py", line 91, in g
    f(self, *args, **kwargs)
  File "/home/gl/.local/lib/python3.4/site-packages/supybot/callbacks.py", line 1248, in callCommand
    method(irc, msg, *args, **kwargs)
  File "/home/gl/.local/lib/python3.4/site-packages/supybot/commands.py", line 1079, in newf
    f(self, irc, msg, args, *state.args, **state.kwargs)
  File "/home/gl/.local/lib/python3.4/site-packages/supybot/plugins/Owner/plugin.py", line 454, in reload
    x = module.reload()
TypeError: reload() missing 1 required positional argument: 'module'
ERROR 2014-11-03T07:40:30 Exception id: 0x58ded
```
