### PR TITLE
Debug: Fix __init__.py for Python 3 compatibility

### DIFF
--- a/sandbox/Debug/__init__.py
+++ b/sandbox/Debug/__init__.py
@@ -34,6 +34,7 @@ as well as some other useful commands.
 
 import supybot
 import supybot.world as world
+from sys import version_info
 
 __version__ = "%%VERSION%%"
 
@@ -45,6 +46,8 @@ __contributors__ = {}
 
 from . import config
 from . import plugin
+if version_info[0] >= 3:
+    from imp import reload
 reload(plugin) # In case we're being reloaded.
 
 if world.testing:


### PR DESCRIPTION
This seems to work fine on Python 2.7 & 3.4 without the need for 2to3.
