### PR TITLE
Update .gitignore to include default wizard directories & confs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,11 @@ test-logs/
 src/version.py
 INSTALL
 README.txt
+conf/
+data/
+logs/
+*.conf
+*.conf.bak
 
 # Intellij PyCharm / IDEA related files
 *.iml


### PR DESCRIPTION
I have my current Supybot set up in the same folder as the source, assuming I had installed Supybot before commit 3da554bd (which added a warning about not doing this). This change would prevent these bot-specific files from showing up in `git status`.
