### PR TITLE
Topic refresh

### DIFF
--- a/plugins/Topic/plugin.py
+++ b/plugins/Topic/plugin.py
@@ -515,6 +515,8 @@ class Topic(callbacks.Plugin):
             irc.errorNoCapability(capabilities, Raise=True)
         try:
             topics = self.lastTopics[channel]
+            if not topics:
+                raise KeyError
         except KeyError:
             irc.error(format(_('I haven\'t yet set the topic in %s.'),
                              channel))
@@ -535,9 +537,17 @@ class Topic(callbacks.Plugin):
         topic = irc.state.channels[channel].topic
         if topic:
             self._sendTopics(irc, channel, topic)
-        else:
-            self.restore(irc, msg, args, channel)
-    set = wrap(refresh, ['canChangetopic'])
+            return
+        try:
+            topics = self.lastTopics[channel]
+            if not topics:
+                raise KeyError
+        except KeyError:
+                irc.error(format(_('I haven\'t yet set the topic in %s.'),
+                    channel))
+                return
+        self._sendTopics(irc, channel, topics)
+    refresh = wrap(refresh, ['canChangeTopic'])
 
     @internationalizeDocstring
     def undo(self, irc, msg, args, channel):

--- a/plugins/Topic/test.py
+++ b/plugins/Topic/test.py
@@ -162,6 +162,20 @@ class TopicTestCase(ChannelPluginTestCase):
         finally:
             conf.supybot.plugins.Topic.format.setValue(orig)
 
+    def testRestore(self):
+        self.getMsg('topic set foo')
+        self.assertResponse('topic restore', 'foo')
+        self.getMsg('topic remove 1')
+        restoreError = 'Error: I haven\'t yet set the topic in #test.'
+        self.assertResponse('topic restore', restoreError)
+
+    def testRefresh(self):
+        self.getMsg('topic set foo')
+        self.assertResponse('topic refresh', 'foo')
+        self.getMsg('topic remove 1')
+        refreshError = 'Error: I haven\'t yet set the topic in #test.'
+        self.assertResponse('topic refresh', refreshError)
+
     def testUndo(self):
         try:
             original = conf.supybot.plugins.Topic.format()


### PR DESCRIPTION
Added refresh command in cases where server hasn't set it (large net-splits?). Added testRestore and testRefresh tests. Changes to plugin.py to raise KeyError for empty topics, thus we can assert such a response in tests, this might be useful anyway as setting the topic from an empty list was previous behaviour.
