### PR TITLE
Dict: update hard-coded dictionary names since dict.org has changed them

### DIFF
--- a/plugins/Dict/plugin.py
+++ b/plugins/Dict/plugin.py
@@ -130,7 +130,7 @@ class Dict(callbacks.Plugin):
     def synonym(self, irc, msg, args, words):
         """<word> [<word> ...]
 
-        Gets a random synonym from the Moby Thesaurus (moby-thes) database.
+        Gets a random synonym from the Moby Thesaurus (moby-thesaurus) database.
 
         If given many words, gets a random synonym for each of them.
 
@@ -142,7 +142,7 @@ class Dict(callbacks.Plugin):
         except socket.error as e:
             irc.error(utils.web.strError(e), Raise=True)
 
-        dictionary = 'moby-thes'
+        dictionary = 'moby-thesaurus'
         response = []
         for word in words:
             definitions = conn.define(dictionary, word)

--- a/plugins/Dict/test.py
+++ b/plugins/Dict/test.py
@@ -38,7 +38,7 @@ class DictTestCase(PluginTestCase):
             self.assertNotError('dict flutter')
             self.assertNotRegexp('dict web1913 slash', 'foldoc')
             self.assertError('dict ""')
-            self.assertRegexp('dict eng-fra school', 'école')
+            self.assertRegexp('dict fd-eng-fra school', 'école')
 
         def testDictionaries(self):
             self.assertNotError('dictionaries')


### PR DESCRIPTION
`eng-fra` is now `fd-eng-fra`, and `moby-thes` is now `moby-thesaurus`.

`dictionaries` output as of now (2014-11-23):

all, bouvier, devil, easton, elements, english, fd-afr-deu, fd-cro-eng, fd-cze-eng, fd-dan-eng, fd-deu-eng, fd-deu-fra, fd-deu-ita, fd-deu-nld, fd-deu-por, fd-eng-ara, fd-eng-cro, fd-eng-cze, fd-eng-deu, fd-eng-fra, fd-eng-hin, fd-eng-hun, fd-eng-iri, fd-eng-ita, fd-eng-lat, fd-eng-nld, fd-eng-por, fd-eng-rom, fd-eng-rus, fd-eng-scr, fd-eng-spa, fd-eng-swa, fd-eng-swe, fd-eng-tur, fd-eng-wel, fd-fra-deu, fd-fra-eng, fd-fra-nld, fd-gla-deu, fd-hin-eng, fd-hun-eng, fd-iri-eng, fd-ita-deu, fd-ita-eng, fd-jpn-deu, fd-lat-deu, fd-lat-eng, fd-nld-deu, fd-nld-eng, fd-nld-fra, fd-por-deu, fd-por-eng, fd-scr-eng, fd-slo-eng, fd-spa-eng, fd-swa-eng, fd-swe-eng, fd-tur-deu, fd-tur-eng, fd-wel-eng, foldoc, gaz2k-counties, gaz2k-places, gaz2k-zips, gcide, hitchcock, jargon, moby-thesaurus, trans, vera, wn, and world02
