### PR TITLE
Services: don't warn about unexpected ChanServ notices if the target is a channel

### DIFF
--- a/plugins/Services/plugin.py
+++ b/plugins/Services/plugin.py
@@ -270,8 +270,9 @@ class Services(callbacks.Plugin):
                 self.log.debug('Got entrymsg from ChanServ %s.', on)
         elif ircutils.isChannel(msg.args[0]):
             # Atheme uses channel-wide notices for alerting channel access
-            # changes if the FANTASY setting is on; we can suppress these
-            # 'unexpected notice' warnings since they're not really important.
+            # changes if the FANTASY or VERBOSE setting is on; we can suppress
+            # these 'unexpected notice' warnings since they're not really 
+            # important.
             pass
         else:
             self.log.warning('Got unexpected notice from ChanServ %s: %r.',


### PR DESCRIPTION
Per my comment:

> Atheme uses channel-wide notices for alerting channel access changes if the FANTASY setting is on; we can suppress these 'unexpected notice' warnings since they're not really important.
