### PR TITLE
supybot-plugin-create add --desc option

### DIFF
--- a/scripts/supybot-plugin-create
+++ b/scripts/supybot-plugin-create
@@ -203,7 +203,9 @@ class %sTestCase(PluginTestCase):
 '''.lstrip()
 
 readmeTemplate = '''
-Insert a description of your plugin here, with any notes, etc. about 
+%s
+
+Insert a more detailed description of your plugin here, with any notes, etc. about 
 using it.
 '''.lstrip()
 
@@ -295,7 +297,7 @@ def main():
                                              name))
     writeFile('__init__.py', __init__Template % (copyright, name, options.desc))
     writeFile('test.py', testTemplate % (copyright, name, name))
-    writeFile('README.md', readmeTemplate)
+    writeFile('README.md', readmeTemplate % (options.desc,))
 
     pathname = os.path.join(pathname, 'local')
     os.mkdir(pathname)


### PR DESCRIPTION
Enforce at least a short description? This undos a previous removal of a substitution var and adds options.desc.
