### PR TITLE
Network: make whois reply more clear

### DIFF
--- a/plugins/Network/plugin.py
+++ b/plugins/Network/plugin.py
@@ -243,7 +243,7 @@ class Network(callbacks.Plugin):
                     L.append(format(_('is on %L'), normal))
         else:
             if command == 'whois':
-                L = [_('isn\'t on any non-secret channels')]
+                L = [_('isn\'t on any non-secret channels or has channel list hiding umode')]
             else:
                 L = []
         channels = format('%L', L)


### PR DESCRIPTION
Mention that it's possible that whoised user has channel list hiding
umode. This umode is usually +i, but I say "channel list hiding umode",
because +i is not always the umode which hides user list.

For example Quakenet always forces mode +i to every user and it cannot
be unset, but channel list is still visible. Some other IRCds can have
different modes to hide channel lists than +i.
