### PR TITLE
Reorder: Move the id to the front of the regexp it represents.

### DIFF
--- a/plugins/MessageParser/plugin.py
+++ b/plugins/MessageParser/plugin.py
@@ -404,7 +404,7 @@ class MessageParser(callbacks.Plugin, plugins.ChannelDBHandler):
             irc.reply(_('There are no regexp triggers in the database.'))
             return
 
-        s = [ "#%d: %s" % (regexp[1], regexp[0]) for regexp in regexps ]
+        s = [ "%s: %s" % (ircutils.bold('#'+str(regexp[1])), regexp[0]) for regexp in regexps ]
         separator = self.registryValue('listSeparator', channel)
         irc.reply(separator.join(s))
     list = wrap(list, ['channelOrGlobal'])

--- a/plugins/MessageParser/test.py
+++ b/plugins/MessageParser/test.py
@@ -133,9 +133,9 @@ class MessageParserTestCase(ChannelPluginTestCase):
         self.assertRegexp('messageparser list', 
                 'There are no regexp triggers in the database\.')
         self.assertNotError('messageparser add "stuff" "echo i saw some stuff"')
-        self.assertRegexp('messageparser list', '#1: stuff')
+        self.assertRegexp('messageparser list', '\x02#1\x02: stuff')
         self.assertNotError('messageparser add "aoeu" "echo vowels are nice!"')
-        self.assertRegexp('messageparser list', '#1: stuff, #2: aoeu')
+        self.assertRegexp('messageparser list', '\x02#1\x02: stuff, \x02#2\x02: aoeu')
         
     def testRemove(self):
         self.assertError('messageparser remove "stuff"')


### PR DESCRIPTION
I'd also prefer #<id> than (<id>) but maybe we can discuss that.
