### PR TITLE
Aka: Fix typo and help for 'show'

### DIFF
--- a/plugins/Aka/locales/fi.po
+++ b/plugins/Aka/locales/fi.po
@@ -32,8 +32,8 @@ msgstr "Tämä Aka on jo olemassa."
 
 #: plugin.py:169 plugin.py:181 plugin.py:195 plugin.py:291 plugin.py:308
 #: plugin.py:325
-msgid "This Aka does not exist"
-msgstr "Tätä Akaa ei ole olemassakaan"
+msgid "This Aka does not exist."
+msgstr "Tätä Akaa ei ole olemassakaan."
 
 #: plugin.py:293
 msgid "This Aka is already locked."

--- a/plugins/Aka/plugin.py
+++ b/plugins/Aka/plugin.py
@@ -671,7 +671,7 @@ class Aka(callbacks.Plugin):
                             }), 'user', 'something'])
 
     def show(self, irc, msg, args, optlist, name):
-        """<command>
+        """[--channel <#channel>] <alias>
 
         This command shows the content of an Aka.
         """
@@ -686,7 +686,7 @@ class Aka(callbacks.Plugin):
         if command:
             irc.reply(command)
         else:
-            irc.error(_('This Aka does not exist'))
+            irc.error(_('This Aka does not exist.'))
     show = wrap(show, [getopts({'channel': 'somethingWithoutSpaces'}),
         'text'])
 


### PR DESCRIPTION
Help for `aka show` should now mentions the `--channel` argument (this was implemented but not mentioned).
