### PR TITLE
Seen: insert a specific message when calling seen/any on the bot

### DIFF
--- a/plugins/Seen/plugin.py
+++ b/plugins/Seen/plugin.py
@@ -233,7 +233,7 @@ class Seen(callbacks.Plugin):
         saying. <channel> is only necessary if the message isn't sent on the
         channel itself. <nick> may contain * as a wildcard.
         """
-        if ircutils.strEqual(name, irc.nick):
+        if name and ircutils.strEqual(name, irc.nick):
             irc.reply(_("You've found me!"))
             return
         if msg.nick not in irc.state.channels[channel].users:
@@ -253,7 +253,7 @@ class Seen(callbacks.Plugin):
         and returns the last time user was active in <channel>.  <channel> is
         only necessary if the message isn't sent on the channel itself.
         """
-        if ircutils.strEqual(name, irc.nick):
+        if name and ircutils.strEqual(name, irc.nick):
             irc.reply(_("You've found me!"))
             return
         if msg.nick not in irc.state.channels[channel].users:


### PR DESCRIPTION
Right now Seen will just fail with something like `I have not seen <botnick>`, which is a bit ironic because.. well, the bot is right there! This change makes the bot check to see if `seen` or `any` is being called on the bot's nick.
