### PR TITLE
Math: allow using "^" in place of "**" in calc

### DIFF
--- a/plugins/Math/plugin.py
+++ b/plugins/Math/plugin.py
@@ -186,6 +186,7 @@ class Math(callbacks.Plugin):
                            'underscores or brackets in your mathematical '
                            'expression.  Please remove them.'))
             return
+        text = text.replace("^", "**")
         text = self._calc_remover(text)
         if 'lambda' in text:
             irc.error(_('You can\'t use lambda in this command.'))


### PR DESCRIPTION
`^` is a very common symbol for talking about exponents (as in `2^2`) outside of programming, so it might make sense to allow that in `calc` along with `**`. 

Since the 'bitwise exclusive or' operator (`^` in Python) isn't available in `calc` anyways (it is in `icalc`), this might be useful for user-friendliness. It isn't very obvious that `**` should be used instead of `^` for exponents anyways.
