### PR TITLE
Filter: better colour selection for 'rainbow'

### DIFF
--- a/plugins/Filter/plugin.py
+++ b/plugins/Filter/plugin.py
@@ -401,7 +401,8 @@ class Filter(callbacks.Plugin):
         """
         if sys.version_info[0] < 3:
             text = text.decode('utf-8')
-        colors = utils.iter.cycle(['04', '07', '08', '03', '02', '12', '06'])
+        colors = utils.iter.cycle(['05', '04', '07', '08', '09', '03', '11',
+                                   '10', '12', '02', '06', '13'])
         L = [self._color(c, fg=next(colors)) for c in text]
         if sys.version_info[0] < 3:
             L = [c.encode('utf-8') for c in L]


### PR DESCRIPTION
Basically, this adds more shades to the `rainbow` command to make it flow better on clients with lower colour selections. It is a purely cosmetic change.

![Demonstration of 'rainbow' command](https://dl.dropboxusercontent.com/u/18664770/screenies/supyrainbow.PNG)
