### PR TITLE
Time: refactor code, make tztime respect plugins.Time.format

### DIFF
--- a/plugins/Time/plugin.py
+++ b/plugins/Time/plugin.py
@@ -63,6 +63,11 @@ try:
 except ImportError:
     tzlocal = None
 
+try:
+    import pytz
+except ImportError:
+    pytz = None
+
 class Time(callbacks.Plugin):
     """This plugin allows you to use different time-related functions."""
     @internationalizeDocstring
@@ -190,20 +195,17 @@ class Time(callbacks.Plugin):
     def tztime(self, irc, msg, args, timezone):
         """<region>/<city>
 
-        Takes a city and its region, and returns the locale time. This 
+        Takes a city and its region, and returns its local time. This
         command uses the IANA Time Zone Database."""
-        try:
-            import pytz
-        except ImportError:
+        if pytz is None:
             irc.error(_('Python-tz is required by the command, but is not '
-                        'installed on this computer.'))
-            return
+                        'installed on this computer.'), Raise=True)
         try:
             timezone = pytz.timezone(timezone)
         except pytz.UnknownTimeZoneError:
-            irc.error(_('Unknown timezone'))
-            return
-        irc.reply(datetime.now(timezone).strftime('%F %T%z'))
+            irc.error(_('Unknown timezone'), Raise=True)
+        format = self.registryValue("format", msg.args[0])
+        irc.reply(datetime.now(timezone).strftime(format))
     tztime = wrap(tztime, ['text'])
 
 

--- a/plugins/Time/plugin.py
+++ b/plugins/Time/plugin.py
@@ -159,7 +159,7 @@ class Time(callbacks.Plugin):
                                     TIME.time)])
 
     @internationalizeDocstring
-    def time(self, irc, msg, args, channel, format, seconds):
+    def time(self, irc, msg, args, format, seconds):
         """[<format>] [<seconds since epoch>]
 
         Returns the current time in <format> format, or, if <format> is not
@@ -167,10 +167,7 @@ class Time(callbacks.Plugin):
         <seconds since epoch> time is given, the current time is used.
         """
         if not format:
-            if channel:
-                format = self.registryValue('format', channel)
-            else:
-                format = self.registryValue('format')
+            format = self.registryValue('format', msg.args[0])
         if tzlocal:
             irc.reply(datetime.fromtimestamp(seconds, tzlocal()).strftime(format))
         else:
@@ -178,8 +175,7 @@ class Time(callbacks.Plugin):
             # including at least up to 2.7.5 and 3.2.3. Install dateutil if you
             # can't upgrade Python.
             irc.reply(time.strftime(format, time.localtime(seconds)))
-    time = wrap(time, [optional('channel'), optional('nonInt'),
-                       additional('float', TIME.time)])
+    time = wrap(time, [optional('nonInt'), additional('float', TIME.time)])
 
     @internationalizeDocstring
     def elapsed(self, irc, msg, args, seconds):

--- a/plugins/Time/plugin.py
+++ b/plugins/Time/plugin.py
@@ -159,15 +159,16 @@ class Time(callbacks.Plugin):
                                     TIME.time)])
 
     @internationalizeDocstring
-    def time(self, irc, msg, args, format, seconds):
-        """[<format>] [<seconds since epoch>]
+    def time(self, irc, msg, args, channel, format, seconds):
+        """[<channel>] [<format>] [<seconds since epoch>]
 
         Returns the current time in <format> format, or, if <format> is not
         given, uses the configurable format for the current channel.  If no
-        <seconds since epoch> time is given, the current time is used.
+        <seconds since epoch> time is given, the current time is used. If
+        <channel> is given without <format>, uses the format for <channel>.
         """
         if not format:
-            format = self.registryValue('format', msg.args[0])
+            format = self.registryValue('format', channel or msg.args[0])
         if tzlocal:
             irc.reply(datetime.fromtimestamp(seconds, tzlocal()).strftime(format))
         else:
@@ -175,7 +176,8 @@ class Time(callbacks.Plugin):
             # including at least up to 2.7.5 and 3.2.3. Install dateutil if you
             # can't upgrade Python.
             irc.reply(time.strftime(format, time.localtime(seconds)))
-    time = wrap(time, [optional('nonInt'), additional('float', TIME.time)])
+    time = wrap(time, [optional('channel'), optional('nonInt'),
+                       additional('float', TIME.time)])
 
     @internationalizeDocstring
     def elapsed(self, irc, msg, args, seconds):


### PR DESCRIPTION
In `tztime`:
- Import pytz on load, not every time the command is called.
- Respect `plugins.time.format`.
- Use `irc.error(e, Raise=True)` instead of `return` in error handling.
- Fix a typo in the command description.

In `time`:
- simplify the code used for getting the format configuration (the if statement doesn't appear necessary and the option can just be fetched using `msg.args[0]`).