### PR TITLE
Filter: fix a bug introduced by b78319b

### DIFF
--- a/plugins/Filter/plugin.py
+++ b/plugins/Filter/plugin.py
@@ -619,7 +619,7 @@ class Filter(callbacks.Plugin):
             except KeyError:
                 pass
             write(c)
-        irc.reply(out.getvalue()[1:])
+        irc.reply(out.getvalue().strip())
     spellit = wrap(spellit, ['text'])
 
     @internationalizeDocstring


### PR DESCRIPTION
b78319b caused the first character in text to be cut off if it is not set to be replaced (e.g. a letter
when `config plugins.format.spellit.replaceletters` is off). 