### PR TITLE
BadWords: bug fix, don't kick ops, remove unused import

### DIFF
--- a/plugins/BadWords/plugin.py
+++ b/plugins/BadWords/plugin.py
@@ -83,8 +83,8 @@ class BadWords(callbacks.Privmsg):
                         if c.isHalfopPlus(msg.nick) or \
                                 ircdb.checkCapability(msg.prefix, cap):
                             self.log.debug("Not kicking %s from %s, because "
-                                           "they are immune.", msg.nick,
-                                           channel)
+                                           "they are halfop+ or can't be "
+                                           "kicked.", msg.nick, channel)
                         else:
                             message = self.registryValue('kick.message', channel)
                             irc.queueMsg(ircmsgs.kick(channel, msg.nick, message))


### PR DESCRIPTION
- Remove unused `math` import.
- Don't kick halfop+ users or those with `channel,op`. Closes ProgVal/Limnoria#275.
- Fix a strange bug that causes the bot to kick on **everything** if the last defined bad word is removed (likely because `self.words` is empty and starts matching everything).