### PR TITLE
NickAuth: fix leak of information if 'nick list' is used on a user without a configured nick

### DIFF
--- a/plugins/NickAuth/plugin.py
+++ b/plugins/NickAuth/plugin.py
@@ -131,7 +131,7 @@ class NickAuth(callbacks.Plugin):
                             'network.'), Raise=True)
                 else:
                     irc.error(_('%s has no recognized nick on this '
-                            'network.') % user, Raise=True)
+                            'network.') % user.name, Raise=True)
         list = wrap(list, [optional('networkIrc'),
                            optional('otherUser')])
 


### PR DESCRIPTION
Closes ProgVal/Limnoria#996.