### PR TITLE
PluginDownloader: remove broken repo/unused import

### DIFF
--- a/plugins/PluginDownloader/plugin.py
+++ b/plugins/PluginDownloader/plugin.py
@@ -34,7 +34,6 @@ import sys
 import json
 import shutil
 import urllib
-import urllib2
 import tarfile
 from cStringIO import StringIO
 
@@ -241,10 +240,6 @@ repositories = {
                                                    'SpiderDave',
                                                    'spidey-supybot-plugins',
                                                    'Plugins',
-                                                   ),
-               'Antibody':         GithubRepository(
-                                                   'Antibody',
-                                                   'supybot-plugins',
                                                    ),
                'doorbot':          GithubRepository(
                                                    'hacklab',


### PR DESCRIPTION
Antibody/supybot-plugins does not seem to work anymore, and causes errors with 'repolist'.

edit: 1000th pr/issue! :O