### PR TITLE
add queue arg to irc.reply() for using sendMsg instead of queueMsg

### DIFF
--- a/src/callbacks.py
+++ b/src/callbacks.py
@@ -836,12 +836,12 @@ class NestedCommandsIrcProxy(ReplyIrcProxy):
             else:
                 cb._callCommand(command, self, self.msg, args)
 
-    def reply(self, s, queue=None, noLengthCheck=False, prefixNick=None,
+    def reply(self, s, usequeueMsg=True, noLengthCheck=False, prefixNick=None,
               action=None, private=None, notice=None, to=None, msg=None):
         """
         Keyword arguments:
 
-        * `queue=True`:          False if we should use sendMsg instead
+        * `usequeueMsg=True`:          False if we should use sendMsg instead
                                  of queueMsg
         * `noLengthCheck=False`: True if the length shouldn't be checked
                                  (used for 'more' handling)
@@ -860,7 +860,7 @@ class NestedCommandsIrcProxy(ReplyIrcProxy):
         assert not isinstance(s, ircmsgs.IrcMsg), \
                'Old code alert: there is no longer a "msg" argument to reply.'
         self.repliedTo = True
-        if queue is None:
+        if usequeueMsg:
             sendMsg = self.irc.queueMsg
         else:
             sendMsg = self.irc.sendMsg

--- a/src/callbacks.py
+++ b/src/callbacks.py
@@ -836,11 +836,13 @@ class NestedCommandsIrcProxy(ReplyIrcProxy):
             else:
                 cb._callCommand(command, self, self.msg, args)
 
-    def reply(self, s, noLengthCheck=False, prefixNick=None,
+    def reply(self, s, queue=None, noLengthCheck=False, prefixNick=None,
               action=None, private=None, notice=None, to=None, msg=None):
         """
         Keyword arguments:
 
+        * `queue=True`:          False if we should use sendMsg instead
+                                 of queueMsg
         * `noLengthCheck=False`: True if the length shouldn't be checked
                                  (used for 'more' handling)
         * `prefixNick=True`:     False if the nick shouldn't be prefixed to the
@@ -858,6 +860,10 @@ class NestedCommandsIrcProxy(ReplyIrcProxy):
         assert not isinstance(s, ircmsgs.IrcMsg), \
                'Old code alert: there is no longer a "msg" argument to reply.'
         self.repliedTo = True
+        if queue is None:
+            sendMsg = self.irc.queueMsg
+        else:
+            sendMsg = self.irc.sendMsg
         if msg is None:
             msg = self.msg
         if prefixNick is not None:
@@ -895,7 +901,7 @@ class NestedCommandsIrcProxy(ReplyIrcProxy):
                               action=self.action,
                               private=self.private,
                               prefixNick=self.prefixNick)
-                    self.irc.queueMsg(m)
+                    sendMsg(m)
                     return m
                 else:
                     s = ircutils.safeArgument(s)
@@ -928,7 +934,7 @@ class NestedCommandsIrcProxy(ReplyIrcProxy):
                                   notice=self.notice,
                                   private=self.private,
                                   prefixNick=self.prefixNick)
-                        self.irc.queueMsg(m)
+                        sendMsg(m)
                         return m
                     msgs = ircutils.wrap(s, allowedLength,
                             break_long_words=True)
@@ -941,7 +947,7 @@ class NestedCommandsIrcProxy(ReplyIrcProxy):
                                   notice=self.notice,
                                   private=self.private,
                                   prefixNick=self.prefixNick)
-                        self.irc.queueMsg(m)
+                        sendMsg(m)
                         # XXX We should somehow allow these to be returned, but
                         #     until someone complains, we'll be fine :)  We
                         #     can't return from here, though, for obvious
@@ -974,7 +980,7 @@ class NestedCommandsIrcProxy(ReplyIrcProxy):
                                             notice=self.notice,
                                             private=self.private,
                                             prefixNick=self.prefixNick)
-                    self.irc.queueMsg(m)
+                    sendMsg(m)
                     return m
             finally:
                 self._resetReplyAttributes()


### PR DESCRIPTION
just like it says...

im not positive if it needs to be modified in other reply() functions, but it appears that the one i changed is the main one used. there is also a much simpler reply() in ReplyIrcProxy that uses queueMsg but i do not know when ReplyIrcProxy is used... if not ever from plugin then there is no point of adding arg to it