### PR TITLE
Update Debug to time of shipping as default plugin

### DIFF
--- a/plugins/Debug/README.md
+++ b/plugins/Debug/README.md
@@ -1,1 +1,2 @@
-Insert a description of your plugin here, with any notes, etc. about using it.
+This plugin provides debugging abilities for Supybot. It should not be
+loaded with a default installation.

--- a/plugins/Debug/messages.pot
+++ b/plugins/Debug/messages.pot
@@ -1,0 +1,131 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR ORGANIZATION
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2015-01-22 18:54+EET\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: ENCODING\n"
+"Generated-By: pygettext.py 1.5\n"
+
+
+#: plugin.py:32
+#, docstring
+msgid ""
+"\n"
+"This is for debugging purpouses and you shouldn't load this plugin unless\n"
+"Supybot developer requests you to do so for debugging some issue.\n"
+msgstr ""
+
+#: plugin.py:47
+#, docstring
+msgid "Pseudo-module"
+msgstr ""
+
+#: plugin.py:68
+#, docstring
+msgid ""
+"This plugin provides debugging abilities for Supybot. It\n"
+"    should not be loaded with a default installation."
+msgstr ""
+
+#: plugin.py:89
+#, docstring
+msgid ""
+"<expression>\n"
+"\n"
+"        Evaluates <expression> (which should be a Python expression) and\n"
+"        returns its value.  If an exception is raised, reports the\n"
+"        exception (and logs the traceback to the bot's logfile).\n"
+"        "
+msgstr ""
+
+#: plugin.py:107
+#, docstring
+msgid ""
+"<statement>\n"
+"\n"
+"        Execs <code>.  Returns success if it didn't raise any exceptions.\n"
+"        "
+msgstr ""
+
+#: plugin.py:116
+#, docstring
+msgid ""
+"<expression>\n"
+"\n"
+"        Evaluates the given expression.\n"
+"        "
+msgstr ""
+
+#: plugin.py:127
+#, docstring
+msgid ""
+"<exception name>\n"
+"\n"
+"        Raises the exception matching <exception name>.\n"
+"        "
+msgstr ""
+
+#: plugin.py:139
+#, docstring
+msgid ""
+"<raw IRC message>\n"
+"\n"
+"        Sends (not queues) the raw IRC message given.\n"
+"        "
+msgstr ""
+
+#: plugin.py:148
+#, docstring
+msgid ""
+"[<filename>]\n"
+"\n"
+"        Starts tracing function calls to <filename>.  If <filename> is not\n"
+"        given, sys.stdout is used.  This causes much output.\n"
+"        "
+msgstr ""
+
+#: plugin.py:162
+#, docstring
+msgid ""
+"takes no arguments\n"
+"\n"
+"        Stops tracing function calls on stdout.\n"
+"        "
+msgstr ""
+
+#: plugin.py:171
+#, docstring
+msgid ""
+"[<channel>]\n"
+"\n"
+"        Returns the result of the channeldb converter.\n"
+"        "
+msgstr ""
+
+#: plugin.py:179
+#, docstring
+msgid ""
+"[<times>]\n"
+"\n"
+"        Does <times> gc collections, returning the number of objects collected\n"
+"        each time.  <times> defaults to 1.\n"
+"        "
+msgstr ""
+
+#: plugin.py:192
+#, docstring
+msgid ""
+"takes no arguments\n"
+"\n"
+"        Returns the environment of the supybot process.\n"
+"        "
+msgstr ""
+

--- a/plugins/Debug/messages.pot
+++ b/plugins/Debug/messages.pot
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-01-22 18:54+EET\n"
+"POT-Creation-Date: 2015-01-23 08:27+EET\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,8 +19,8 @@ msgstr ""
 #, docstring
 msgid ""
 "\n"
-"This is for debugging purpouses and you shouldn't load this plugin unless\n"
-"Supybot developer requests you to do so for debugging some issue.\n"
+"This is for debugging purposes only and you shouldn't load this it unless\n"
+"a Supybot developer requests you to debug some issue.\n"
 msgstr ""
 
 #: plugin.py:47

--- a/plugins/Debug/plugin.py
+++ b/plugins/Debug/plugin.py
@@ -30,8 +30,8 @@
 ###
 
 """
-This is for jemfinch's debugging only.  If this somehow gets added and
-committed, remove it immediately.  It must not be released with Supybot.
+This is for debugging purpouses and you shouldn't load this plugin unless
+Supybot developer requests you to do so for debugging some issue.
 """
 
 import supybot.plugins as plugins

--- a/plugins/Debug/plugin.py
+++ b/plugins/Debug/plugin.py
@@ -30,8 +30,8 @@
 ###
 
 """
-This is for debugging purpouses and you shouldn't load this plugin unless
-Supybot developer requests you to do so for debugging some issue.
+This is for debugging purposes only and you shouldn't load this it unless
+a Supybot developer requests you to debug some issue.
 """
 
 import supybot.plugins as plugins


### PR DESCRIPTION
* Rewrite README.md based on `plugin help Debug`.
* Update string that I am not sure what it was, but it's not accurate anymore.
* add messages.pot & locales/.
    * `.gitignore` is there to avoid git removing the directory and it can be removed as translations are added. I don't feel like translating at the moment and this seems very difficult plugin to translate if this should even be translatable.