### PR TITLE
irclib.py: fix an encoding error with Python 3 and SASL ECDSA-NIST256P-CHALLENGE

### DIFF
--- a/src/irclib.py
+++ b/src/irclib.py
@@ -1009,7 +1009,7 @@ class Irc(IrcCommandDispatcher):
                 private_key = SigningKey.from_pem(open(self.sasl_ecdsa_key).
                     read())
                 authstring = base64.b64encode(
-                    private_key.sign(base64.b64decode(msg.args[0]))).decode('utf-8')
+                    private_key.sign(base64.b64decode(msg.args[0].encode()))).decode('utf-8')
             except (BadDigestError, OSError, ValueError) as e:
                 authstring = "*"
 


### PR DESCRIPTION
Temporary fix for #1028, though this may cause ECDSA-NIST256P-CHALLENGE to fail entirely (blocking the bot from connecting is a more severe issue).