### PR TITLE
Network: default 'whois' to current nick if not specified

### DIFF
--- a/plugins/Network/plugin.py
+++ b/plugins/Network/plugin.py
@@ -310,10 +310,12 @@ class Network(callbacks.Plugin):
         # The double nick here is necessary because single-nick WHOIS only works
         # if the nick is on the same server (*not* the same network) as the user
         # giving the command.  Yeah, it made me say wtf too.
+        if nick is None:
+            nick = msg.nick
         nick = ircutils.toLower(nick)
         otherIrc.queueMsg(ircmsgs.whois(nick, nick))
         self._whois[(otherIrc, nick)] = (irc, msg, {}, 'whois')
-    whois = wrap(whois, ['networkIrc', 'nick'])
+    whois = wrap(whois, ['networkIrc', additional('nick')])
 
     @internationalizeDocstring
     def whowas(self, irc, msg, args, otherIrc, nick):


### PR DESCRIPTION
This is mostly a change for convenience, allowing easy whoising of yourself in a channel. 

However, one side effect of this is that: whoising a person who's nick = the current network name will require specifying the person's name twice. 

Running `whois <network>` will try to whois your current nick on network `<network>`.