### PR TITLE
Admin/Owner: substitute $version in quit and part messages (also make part messages configurable)

### DIFF
--- a/plugins/Admin/config.py
+++ b/plugins/Admin/config.py
@@ -43,8 +43,11 @@ def configure(advanced):
 
 
 Admin = conf.registerPlugin('Admin')
-# This is where your configuration variables (if any) should go.  For example:
-# conf.registerGlobalValue(Admin, 'someConfigVariableName',
-#     registry.Boolean(False, """Help for someConfigVariableName."""))
+
+conf.registerChannelValue(Admin, 'partMsg',
+    registry.String('%version%', _("""Determines what part message should be
+        used by default. If the part command is called without a part message,
+        this will be used. If this value is empty, then no part message will
+        be used (they are optional in the IRC protocol).""")))
 
 # vim:set shiftwidth=4 softtabstop=4 expandtab textwidth=79:

--- a/plugins/Admin/config.py
+++ b/plugins/Admin/config.py
@@ -45,9 +45,10 @@ def configure(advanced):
 Admin = conf.registerPlugin('Admin')
 
 conf.registerChannelValue(Admin, 'partMsg',
-    registry.String('%version%', _("""Determines what part message should be
+    registry.String('$version', _("""Determines what part message should be
         used by default. If the part command is called without a part message,
         this will be used. If this value is empty, then no part message will
-        be used (they are optional in the IRC protocol).""")))
+        be used (they are optional in the IRC protocol). The standard
+        substitutions ($version, $nick, etc.) are all handled appropriately.""")))
 
 # vim:set shiftwidth=4 softtabstop=4 expandtab textwidth=79:

--- a/plugins/Admin/plugin.py
+++ b/plugins/Admin/plugin.py
@@ -238,7 +238,9 @@ class Admin(callbacks.Plugin):
         Tells the bot to part the list of channels you give it.  <channel> is
         only necessary if you want the bot to part a channel other than the
         current channel.  If <reason> is specified, use it as the part
-        message.
+        message.  Otherwise, the default part message specified in
+        supybot.plugins.Admin.partMsg will be used. No part message will be
+        used if no default is configured.
         """
         if channel is None:
             if irc.isChannel(msg.args[0]):
@@ -252,7 +254,9 @@ class Admin(callbacks.Plugin):
             pass
         if channel not in irc.state.channels:
             irc.error(_('I\'m not in %s.') % channel, Raise=True)
-        irc.queueMsg(ircmsgs.part(channel, reason or msg.nick))
+        reason = (reason or self.registryValue("partMsg", channel))
+        reason = reason.replace("%version%", "Supybot %s" % conf.version)
+        irc.queueMsg(ircmsgs.part(channel, reason))
         if msg.nick in irc.state.channels[channel].users:
             irc.noReply()
         else:

--- a/plugins/Admin/plugin.py
+++ b/plugins/Admin/plugin.py
@@ -255,7 +255,7 @@ class Admin(callbacks.Plugin):
         if channel not in irc.state.channels:
             irc.error(_('I\'m not in %s.') % channel, Raise=True)
         reason = (reason or self.registryValue("partMsg", channel))
-        reason = reason.replace("%version%", "Supybot %s" % conf.version)
+        reason = ircutils.standardSubstitute(irc, msg, reason)
         irc.queueMsg(ircmsgs.part(channel, reason))
         if msg.nick in irc.state.channels[channel].users:
             irc.noReply()

--- a/plugins/Owner/config.py
+++ b/plugins/Owner/config.py
@@ -46,10 +46,11 @@ conf.registerGlobalValue(Owner, 'public',
     registry.Boolean(True, """Determines whether this plugin is publicly
     visible."""))
 conf.registerGlobalValue(Owner, 'quitMsg',
-    registry.String('%version%', """Determines what quit message will be used by default.
+    registry.String('$version', """Determines what quit message will be used by default.
     If the quit command is called without a quit message, this will be used.  If
     this value is empty, the nick of the person giving the quit command will be
-    used.  %version% is automatically expanded to the bot's current version."""))
+    used.  The standard substitutions ($version, $nick, etc.) are all handled
+    appropriately."""))
 
 conf.registerGroup(conf.supybot.commands, 'renames', orderAlphabetically=True)
 

--- a/plugins/Owner/plugin.py
+++ b/plugins/Owner/plugin.py
@@ -344,11 +344,11 @@ class Owner(callbacks.Plugin):
 
         Exits the bot with the QUIT message <text>.  If <text> is not given,
         the default quit message (supybot.plugins.Owner.quitMsg) will be used.
-        If there is no default quitMsg set, your nick will be used. %version%
-        is automatically expanded to the bot's current version.
+        If there is no default quitMsg set, your nick will be used. The standard
+        substitutions ($version, $nick, etc.) are all handled appropriately.
         """
         text = text or self.registryValue('quitMsg') or msg.nick
-        text = text.replace("%version%", "Supybot %s" % conf.version)
+        text = ircutils.standardSubstitute(irc, msg, text)
         irc.noReply()
         m = ircmsgs.quit(text)
         world.upkeep()

--- a/scripts/supybot
+++ b/scripts/supybot
@@ -69,6 +69,7 @@ import supybot.i18n as i18n
 import supybot.utils as utils
 import supybot.registry as registry
 import supybot.questions as questions
+import supybot.ircutils as ircutils
 
 from supybot.version import version
 
@@ -104,6 +105,8 @@ def main():
                 for irc in world.ircs:
                     quitmsg = conf.supybot.plugins.Owner.quitMsg() or \
                               'Ctrl-C at console.'
+                    msg = ircmsgs.ping('Ctrl-C at console.')
+                    quitmsg = ircutils.standardSubstitute(irc, msg, quitmsg)
                     irc.queueMsg(ircmsgs.quit(quitmsg))
                     irc.die()
         except SystemExit as e:

--- a/scripts/supybot
+++ b/scripts/supybot
@@ -105,8 +105,7 @@ def main():
                 for irc in world.ircs:
                     quitmsg = conf.supybot.plugins.Owner.quitMsg() or \
                               'Ctrl-C at console.'
-                    msg = ircmsgs.ping('Ctrl-C at console.')
-                    quitmsg = ircutils.standardSubstitute(irc, msg, quitmsg)
+                    quitmsg = ircutils.standardSubstitute(irc, None, quitmsg)
                     irc.queueMsg(ircmsgs.quit(quitmsg))
                     irc.die()
         except SystemExit as e:

--- a/src/callbacks.py
+++ b/src/callbacks.py
@@ -926,7 +926,13 @@ class NestedCommandsIrcProxy(ReplyIrcProxy):
                         # In case we're truncating, we add 20 to allowedLength,
                         # because our allowedLength is shortened for the
                         # "(XX more messages)" trailer.
-                        s = s[:allowedLength+len(_('(XX more messages)'))]
+                        if sys.version_info[0] >= 3:
+                            appended = _('(XX more messages)').encode()
+                            s = s.encode()[:allowedLength+len(appended)]
+                            s = s.decode('utf8', 'ignore')
+                        else:
+                            appended = _('(XX more messages)')
+                            s = s[:allowedLength+len(appended)]
                         # There's no need for action=self.action here because
                         # action implies noLengthCheck, which has already been
                         # handled.  Let's stick an assert in here just in case.

--- a/src/ircutils.py
+++ b/src/ircutils.py
@@ -49,7 +49,7 @@ from cStringIO import StringIO as sio
 
 from . import utils
 from . import minisix
-
+from .version import version
 
 def debug(s, *args):
     """Prints a debug string.  Most likely replaced by our logging debug."""
@@ -713,6 +713,7 @@ def standardSubstitute(irc, msg, text, env=None):
         'm': localtime[4], 'min': localtime[4], 'minute': localtime[4],
         's': localtime[5], 'sec': localtime[5], 'second': localtime[5],
         'tz': time.strftime('%Z', localtime),
+        'version': 'Supybot %s' % version,
         })
     if msg.reply_env:
         vars.update(msg.reply_env)


### PR DESCRIPTION
Closes #391.

This also makes the default part message the Supybot version instead of the nick's caller. Quit messages are optional anyways for IRC, so just having someone's nick inside a part message isn't very intuitive or meaningful. When `config plugins.admin.partmsg` is blank, simply no part message will be used.

edit: This also merges the changes in #1043 and supports other substitutions too (`$nick`, etc.).