### PR TITLE
Channel: prevent mass-highlights with 'nicks' by defaulting the output to private

### DIFF
--- a/plugins/Channel/config.py
+++ b/plugins/Channel/config.py
@@ -47,6 +47,10 @@ Channel = conf.registerPlugin('Channel')
 conf.registerChannelValue(Channel, 'alwaysRejoin',
     registry.Boolean(True, _("""Determines whether the bot will always try to
     rejoin a channel whenever it's kicked from the channel.""")))
+conf.registerChannelValue(Channel, 'nicksInPrivate',
+    registry.Boolean(True, _("""Determines whether the output of 'nicks' will
+    be sent in private. This prevents mass-highlights of a channel's users,
+    accidental or on purpose.""")))
 
 
 # vim:set shiftwidth=4 softtabstop=4 expandtab textwidth=79:

--- a/plugins/Channel/plugin.py
+++ b/plugins/Channel/plugin.py
@@ -910,7 +910,8 @@ class Channel(callbacks.Plugin):
         keys = [option for (option, arg) in optlist]
         if 'count' not in keys:
             utils.sortBy(str.lower, L)
-            irc.reply(utils.str.commaAndify(L))
+            private = self.registryValue("nicksInPrivate", channel)
+            irc.reply(utils.str.commaAndify(L), private=private)
         else:
             irc.reply(str(len(L)))
     nicks = wrap(nicks, ['inChannel',


### PR DESCRIPTION
This adds a new config variable `plugins.Channel.nicksInPrivate`. The idea of this change is to prevent people from spamming a channel with mass-highlights using the `nicks` command, without disabling or limiting it entirely. This is hopefully a sane default to minimize bot abuse.

(`nicks --count` is not affected by this option, just `nicks` without arguments is.)