### PR TITLE
Owner: substitute %version% for the Supybot version in plugins.Owner.quitmsg

### DIFF
--- a/plugins/Owner/config.py
+++ b/plugins/Owner/config.py
@@ -46,10 +46,10 @@ conf.registerGlobalValue(Owner, 'public',
     registry.Boolean(True, """Determines whether this plugin is publicly
     visible."""))
 conf.registerGlobalValue(Owner, 'quitMsg',
-    registry.String('', """Determines what quit message will be used by default.
+    registry.String('%version%', """Determines what quit message will be used by default.
     If the quit command is called without a quit message, this will be used.  If
     this value is empty, the nick of the person giving the quit command will be
-    used."""))
+    used.  %version% is automatically expanded to the bot's current version."""))
 
 conf.registerGroup(conf.supybot.commands, 'renames', orderAlphabetically=True)
 

--- a/plugins/Owner/plugin.py
+++ b/plugins/Owner/plugin.py
@@ -344,9 +344,11 @@ class Owner(callbacks.Plugin):
 
         Exits the bot with the QUIT message <text>.  If <text> is not given,
         the default quit message (supybot.plugins.Owner.quitMsg) will be used.
-        If there is no default quitMsg set, your nick will be used.
+        If there is no default quitMsg set, your nick will be used. %version%
+        is automatically expanded to the bot's current version.
         """
         text = text or self.registryValue('quitMsg') or msg.nick
+        text = text.replace("%version%", "Supybot %s" % conf.version)
         irc.noReply()
         m = ircmsgs.quit(text)
         world.upkeep()


### PR DESCRIPTION
Closes #847. This also changes the default quit message to the Supybot version. 

Rephrasing my argument on #1041, I feel that having a person's nick in a default quit message isn't meaningful at all. If `plugins.owner.quitmsg` is empty, only then will the caller's nick be used.