### PR TITLE
src/i18n.py: mention supported languages

### DIFF
--- a/src/i18n.py
+++ b/src/i18n.py
@@ -70,7 +70,8 @@ def import_conf():
     conf = __import__('supybot.conf').conf
     conf.registerGlobalValue(conf.supybot, 'language',
         conf.registry.String(currentLocale, """Determines the bot's default
-        language. Valid values are things like en, fr, de, etc."""))
+        language if translations exist. Currently supported are de, es, fi,
+        fr and it."""))
     conf.supybot.language.addCallback(reloadLocalesIfRequired)
 
 def getPluginDir(plugin_name):


### PR DESCRIPTION
Closes #1046

I used Admin for sources of what languages are supported as it's usually
recommended to start translating from there (first plugins, then core).