### PR TITLE
Gpg extension - fix subkey/master key conflict

### DIFF
--- a/plugins/User/plugin.py
+++ b/plugins/User/plugin.py
@@ -524,56 +524,28 @@ class User(callbacks.Plugin):
                     'Authentication aborted.'), Raise=True)
             verified = gpg.keyring.verify(data)
             if verified and verified.valid:
-                keyid = verified.key_id
+                keyid0 = verified.key_id
                 fprint = verified.pubkey_fingerprint
                 kprint = fprint[-16:]
                 prefix, expiry = self._tokens.pop(token)
                 found = False
-                pkeys = gpg.list_keys(False)
-                pnum = len(pkeys)
-                for x in range(pnum):
-                    if keyid or kprint in pkeys[x]["keyid"] and keyid in user.gpgkeys and if keyid is kprint:
+                if keyid0 == kprint:
+                    keyid = keyid0
+                else:
+                    keyid = kprint
+                for (id, user) in ircdb.users.items():
+                    if keyid in [x[-len(keyid):] for x in user.gpgkeys]:
                         user.addAuth(msg.prefix)
+                        try:
+                            user.addAuth(msg.prefix)
+                        except ValueError:
+                            irc.error(_('Your secure flag is true and your '
+                                      'hostmask doesn\'t match any of your '
+                                      'known hostmasks.'), Raise=True)
                         ircdb.users.setUser(user, flush=False)
-                        irc.reply(_('You are now authenticated as %s with %s.')
-                                  % (user.name, keyid))
+                        irc.reply(_('You are now authenticated as %s.') %
+                                user.name)
                         return
-                    elif keyid or kprint in pkeys[x]["keyid"] and keyid not in user.gpgkeys and kprint is in user.gpgkeys and keyid is not kprint:
-                        user.addAuth(msg.prefix)
-                        ircdb.users.setUser(user, flush=False)
-                        irc.reply(_('You are now authenticated as %s with %s using the %s subkey.')
-                                  % (user.name, keyid, kprint))
-                        return
-                    elif keyid or kprint in pkeys[x]["keyid"] and keyid is kprint and keyid not in user.gpgkeys:
-                        irc.error(_('I have a record of key %s, but it is not associated with the %s account.') % (keyid, user.name))
-                        return
-                    elif keyid or kprint in pkeys[x]["keyid"] and keyid is not kprint and keyid not in user.gpgkeys and kprint not in user.gpgkeys:
-                        irc.error(_('I have a record of key %s, but it is not associated with any account.') % (keyid))
-                        return
-                    elif keyid is kprint and keyid not in pkeys[x]["keyid"] and keyid in user.gpgkeys:
-                        irc.error(_('The %s key is registered to the %s account, but not currently available to me.  Please add the key again') % (keyid, user.name))
-                        # Possibly replace this with key retrieval attempt.
-                        # try:
-                        #     code to retrieve key from server
-                        # except AnErrorOfSomeKind:
-                        #     the current error message.
-                        return
-                        elif keyid and kprint not in pkeys[x]["keyid"] and keyid is not kprint and keyid not in user.gpgkeys and kprint not in user.gpgkeys:
-                        irc.error(_('Unknown GPG key.'), Raise=True)
-                        return
-                #for (id, user) in ircdb.users.items():
-                #    if keyid in [x[-len(keyid):] for x in user.gpgkeys]:
-                #        user.addAuth(msg.prefix)
-                #        try:
-                #            user.addAuth(msg.prefix)
-                #        except ValueError:
-                #            irc.error(_('Your secure flag is true and your '
-                #                      'hostmask doesn\'t match any of your '
-                #                      'known hostmasks.'), Raise=True)
-                #        ircdb.users.setUser(user, flush=False)
-                #        irc.reply(_('You are now authenticated as %s.') %
-                #                user.name)
-                #        return
                 irc.error(_('Unknown GPG key.'), Raise=True)
             else:
                 irc.error(_('Signature could not be verified. Make sure '

--- a/plugins/User/plugin.py
+++ b/plugins/User/plugin.py
@@ -524,15 +524,9 @@ class User(callbacks.Plugin):
                     'Authentication aborted.'), Raise=True)
             verified = gpg.keyring.verify(data)
             if verified and verified.valid:
-                keyid0 = verified.key_id
-                fprint = verified.pubkey_fingerprint
-                kprint = fprint[-16:]
+                keyid = verified.pubkey_fingerprint[-16:]
                 prefix, expiry = self._tokens.pop(token)
                 found = False
-                if keyid0 == kprint:
-                    keyid = keyid0
-                else:
-                    keyid = kprint
                 for (id, user) in ircdb.users.items():
                     if keyid in [x[-len(keyid):] for x in user.gpgkeys]:
                         try:

--- a/plugins/User/plugin.py
+++ b/plugins/User/plugin.py
@@ -535,7 +535,6 @@ class User(callbacks.Plugin):
                     keyid = kprint
                 for (id, user) in ircdb.users.items():
                     if keyid in [x[-len(keyid):] for x in user.gpgkeys]:
-                        user.addAuth(msg.prefix)
                         try:
                             user.addAuth(msg.prefix)
                         except ValueError:


### PR DESCRIPTION
Still to be tested in a live bot, but the individual lines work as expected.

Essentially verified.key_id is always the long user ID of the key which makes the signature, while verified.pubkey_fingerprint is always the fingerprint of the master key.  If the last 16 characters of the fingerprint match the signing key ID then keyid should be as it was (keyid = verified.key_id), but if they don't match then we want keyid set to the long key ID of the master key (keyid = verified.pubkey_fingerprint[-16:]).  Once keyid is set appropriately, the existing code continues as normal with the correct values.

This addresses the second bug listed in Issue #1045 (which I lodged a few hours ago).
