### PR TITLE
src/i18n.py: have languages in alphabetical order

### DIFF
--- a/src/i18n.py
+++ b/src/i18n.py
@@ -70,7 +70,7 @@ def import_conf():
     conf = __import__('supybot.conf').conf
     conf.registerGlobalValue(conf.supybot, 'language',
         conf.registry.String(currentLocale, """Determines the bot's default
-        language if translations exist. Currently supported are 'en', 'de',
+        language if translations exist. Currently supported are 'de', 'en',
         'es', 'fi', 'fr' and 'it'."""))
     conf.supybot.language.addCallback(reloadLocalesIfRequired)
 


### PR DESCRIPTION
It's probably not so important, but I don't like them being in any
strange random order. Of course having English first would make sense as
it's the default, but I still prefer alphabetical order.