### PR TITLE
Aka: prevent DoS attacks with recursive Akas

### DIFF
--- a/plugins/Aka/config.py
+++ b/plugins/Aka/config.py
@@ -55,6 +55,8 @@ conf.registerGlobalValue(Aka, 'maximumWordsInName',
     registry.Integer(5, _("""The maximum number of words allowed in a
     command name. Setting this to an high value may slow down your bot
     on long commands.""")))
-
-
+conf.registerGlobalValue(Aka, 'recursionLimit',
+    registry.NonNegativeInteger(8, _("""Determines the maximum level of Aka recursion
+    (Akas calling other Akas) allowed. This can help effectively stop DDoS attempts that
+    call one or more Akas in a loop. If set to zero, this check is disabled.""")))
 # vim:set shiftwidth=4 tabstop=4 expandtab textwidth=79:

--- a/plugins/Aka/test.py
+++ b/plugins/Aka/test.py
@@ -175,7 +175,7 @@ class AkaChannelTestCase(ChannelPluginTestCase):
                 r'"cif [nceq $1 0] \"echo 1\" '
                 r'\"calc $1 * [fact [calc $1 - 1]]\""')
         self.assertResponse('fact 4', '24')
-        self.assertRegexp('fact 50', 'more nesting')
+        self.assertRegexp('fact 50', 'more nesting|too much recursion')
 
     def testDollarStarNesting(self):
         self.assertNotError('aka add alias aka $*')


### PR DESCRIPTION
This change makes Aka keep track of all aliases (tokens) called during the expansion of an Aka, which aims to block most recursion-based DoS attempts. (Really fixes #526)

It will catch and terminate execution when of an Aka when either:

1. The same command & arguments are called multiple times during expansion of one Aka.
    - For example: `aka add test test` will call the `test` command endlessly if `test` is called once.

2. The amount of Akas called in expansion exceeds the limit set in `supybot.plugins.Aka.recursionLimit` (new variable). This can be used to block attacks such as:
    - `aka add test test $1$1$1$1$*`, where the command is recursive but the arguments change & grow infinitely large over time.
    - `aka add test test2`, `aka add test2 test`: any situation where a group of aliases are chained to call each other without stopping.
