### PR TITLE
Network.whois: simplify message when user isn't on any public channels

### DIFF
--- a/plugins/Network/plugin.py
+++ b/plugins/Network/plugin.py
@@ -243,7 +243,7 @@ class Network(callbacks.Plugin):
                     L.append(format(_('is on %L'), normal))
         else:
             if command == 'whois':
-                L = [_('isn\'t on any publically visible channels')]
+                L = [_('isn\'t on any publicly visible channels')]
             else:
                 L = []
         channels = format('%L', L)

--- a/plugins/Network/plugin.py
+++ b/plugins/Network/plugin.py
@@ -243,8 +243,7 @@ class Network(callbacks.Plugin):
                     L.append(format(_('is on %L'), normal))
         else:
             if command == 'whois':
-                L = [_('isn\'t on any non-secret channels or is using a '
-                    'channel-list hiding umode.')]
+                L = [_('isn\'t on any publically visible channels')]
             else:
                 L = []
         channels = format('%L', L)


### PR DESCRIPTION
The current message ("xyz isn't on any non-secret channels or is using a channel-list hiding umode.") is long and awkwardly worded. 

This also removes an extra period from showing up at the end of the output.