### PR TITLE
Channel: allow adding an auto-rejoin delay

### DIFF
--- a/plugins/Channel/config.py
+++ b/plugins/Channel/config.py
@@ -51,6 +51,9 @@ conf.registerChannelValue(Channel, 'nicksInPrivate',
     registry.Boolean(True, _("""Determines whether the output of 'nicks' will
     be sent in private. This prevents mass-highlights of a channel's users,
     accidental or on purpose.""")))
-
+conf.registerChannelValue(Channel, 'rejoinDelay',
+    registry.NonNegativeInteger(0, _("""Determines how many seconds the bot will wait
+    before rejoining a channel if kicked and
+    supybot.plugins.Channel.alwaysRejoin is on.""")))
 
 # vim:set shiftwidth=4 softtabstop=4 expandtab textwidth=79:


### PR DESCRIPTION
This is done via the config variable `supybot.plugins.Channel.rejoinDelay`. Closes #1011.

The timing of the rejoins isn't super-exact because of `schedule.addEvent()` being used (the bot might join one second slower than what's set), but it should be fine for most purposes. When `rejoinDelay` is turned off, everything skips the scheduling and the rejoin is actually instant.