### PR TITLE
Move 'part' command from Admin to Channel and use part messages in Channel.cycle

### DIFF
--- a/plugins/Admin/config.py
+++ b/plugins/Admin/config.py
@@ -41,10 +41,6 @@ def configure(advanced):
     from supybot.questions import expect, anything, something, yn
     conf.registerPlugin('Admin', True)
 
-
 Admin = conf.registerPlugin('Admin')
-# This is where your configuration variables (if any) should go.  For example:
-# conf.registerGlobalValue(Admin, 'someConfigVariableName',
-#     registry.Boolean(False, """Help for someConfigVariableName."""))
 
 # vim:set shiftwidth=4 softtabstop=4 expandtab textwidth=79:

--- a/plugins/Admin/plugin.py
+++ b/plugins/Admin/plugin.py
@@ -232,33 +232,6 @@ class Admin(callbacks.Plugin):
     nick = wrap(nick, [additional('nick'), additional('something')])
 
     @internationalizeDocstring
-    def part(self, irc, msg, args, channel, reason):
-        """[<channel>] [<reason>]
-
-        Tells the bot to part the list of channels you give it.  <channel> is
-        only necessary if you want the bot to part a channel other than the
-        current channel.  If <reason> is specified, use it as the part
-        message.
-        """
-        if channel is None:
-            if irc.isChannel(msg.args[0]):
-                channel = msg.args[0]
-            else:
-                irc.error(Raise=True)
-        try:
-            network = conf.supybot.networks.get(irc.network)
-            network.channels().remove(channel)
-        except KeyError:
-            pass
-        if channel not in irc.state.channels:
-            irc.error(_('I\'m not in %s.') % channel, Raise=True)
-        irc.queueMsg(ircmsgs.part(channel, reason or msg.nick))
-        if msg.nick in irc.state.channels[channel].users:
-            irc.noReply()
-        else:
-            irc.replySuccess()
-    part = wrap(part, [optional('validChannel'), additional('text')])
-
     class capability(callbacks.Commands):
 
         @internationalizeDocstring

--- a/plugins/Admin/test.py
+++ b/plugins/Admin/test.py
@@ -94,27 +94,6 @@ class AdminTestCase(PluginTestCase):
         self.assertEqual(m.args[0], '#foo')
         self.assertEqual(m.args[1], 'key')
 
-    def testPart(self):
-        def getAfterJoinMessages():
-            m = self.irc.takeMsg()
-            self.assertEqual(m.command, 'MODE')
-            m = self.irc.takeMsg()
-            self.assertEqual(m.command, 'MODE')
-            m = self.irc.takeMsg()
-            self.assertEqual(m.command, 'WHO')
-        self.assertError('part #foo')
-        self.assertRegexp('part #foo', 'not in')
-        self.irc.feedMsg(ircmsgs.join('#foo', prefix=self.prefix))
-        getAfterJoinMessages()
-        m = self.getMsg('part #foo')
-        self.assertEqual(m.command, 'PART')
-        self.irc.feedMsg(ircmsgs.join('#foo', prefix=self.prefix))
-        getAfterJoinMessages()
-        m = self.getMsg('part #foo reason')
-        self.assertEqual(m.command, 'PART')
-        self.assertEqual(m.args[0], '#foo')
-        self.assertEqual(m.args[1], 'reason')
-
     def testNick(self):
         original = conf.supybot.nick()
         try:

--- a/plugins/Channel/config.py
+++ b/plugins/Channel/config.py
@@ -51,6 +51,11 @@ conf.registerChannelValue(Channel, 'nicksInPrivate',
     registry.Boolean(True, _("""Determines whether the output of 'nicks' will
     be sent in private. This prevents mass-highlights of a channel's users,
     accidental or on purpose.""")))
-
+conf.registerChannelValue(Channel, 'partMsg',
+    registry.String('$version', _("""Determines what part message should be
+        used by default. If the part command is called without a part message,
+        this will be used. If this value is empty, then no part message will
+        be used (they are optional in the IRC protocol). The standard
+        substitutions ($version, $nick, etc.) are all handled appropriately.""")))
 
 # vim:set shiftwidth=4 softtabstop=4 expandtab textwidth=79:

--- a/plugins/Channel/plugin.py
+++ b/plugins/Channel/plugin.py
@@ -258,17 +258,22 @@ class Channel(callbacks.Plugin):
                              any('nickInChannel')])
 
     @internationalizeDocstring
-    def cycle(self, irc, msg, args, channel):
+    def cycle(self, irc, msg, args, channel, reason):
         """[<channel>]
 
         If you have the #channel,op capability, this will cause the bot to
         "cycle", or PART and then JOIN the channel. <channel> is only necessary
-        if the message isn't sent in the channel itself.
+        if the message isn't sent in the channel itself. If <reason> is not
+        specified, the default part message specified in
+        supybot.plugins.Channel.partMsg will be used. No part message will be
+        used if neither a cycle reason nor a default part message is given.
         """
-        self._sendMsg(irc, ircmsgs.part(channel, msg.nick))
+        reason = (reason or self.registryValue("partMsg", channel))
+        reason = ircutils.standardSubstitute(irc, msg, reason)
+        self._sendMsg(irc, ircmsgs.part(channel, reason))
         networkGroup = conf.supybot.networks.get(irc.network)
         self._sendMsg(irc, networkGroup.channels.join(channel))
-    cycle = wrap(cycle, ['op'])
+    cycle = wrap(cycle, ['op', additional('text')])
 
     @internationalizeDocstring
     def kick(self, irc, msg, args, channel, nicks, reason):

--- a/plugins/Channel/test.py
+++ b/plugins/Channel/test.py
@@ -251,6 +251,27 @@ class ChannelTestCase(ChannelPluginTestCase):
     def testNicks(self):
         self.assertResponse('channel nicks', 'bar, foo, and test')
         self.assertResponse('channel nicks --count', '3')
-        
+
+    def testPart(self):
+        def getAfterJoinMessages():
+            m = self.irc.takeMsg()
+            self.assertEqual(m.command, 'MODE')
+            m = self.irc.takeMsg()
+            self.assertEqual(m.command, 'MODE')
+            m = self.irc.takeMsg()
+            self.assertEqual(m.command, 'WHO')
+        self.assertError('part #foo')
+        self.assertRegexp('part #foo', 'not in')
+        self.irc.feedMsg(ircmsgs.join('#foo', prefix=self.prefix))
+        getAfterJoinMessages()
+        m = self.getMsg('part #foo')
+        self.assertEqual(m.command, 'PART')
+        self.irc.feedMsg(ircmsgs.join('#foo', prefix=self.prefix))
+        getAfterJoinMessages()
+        m = self.getMsg('part #foo reason')
+        self.assertEqual(m.command, 'PART')
+        self.assertEqual(m.args[0], '#foo')
+        self.assertEqual(m.args[1], 'reason')
+
 # vim:set shiftwidth=4 softtabstop=4 expandtab textwidth=79:
 


### PR DESCRIPTION
This is essentially two changes in one pull request because the changes depend on each other. Closes #79. Closes #1062.

- Move `part` command from Admin to Channel and require `#channel,op` instead of admin.
- `Channel.cycle`: allow specifying part message that defaults to `plugins.Channel.partMsg`.
