### PR TITLE
conf.py: Remove reference to non-existent "user configuration variable"

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -470,8 +470,7 @@ registerChannelValue(supybot.reply, 'withNotice',
 registerGlobalValue(supybot.reply, 'withNoticeWhenPrivate',
     registry.Boolean(True, _("""Determines whether the bot will reply with a
     notice when it is sending a private message, in order not to open a /query
-    window in clients.  This can be overridden by individual users via the user
-    configuration variable reply.withNoticeWhenPrivate.""")))
+    window in clients.""")))
 
 registerChannelValue(supybot.reply, 'withNickPrefix',
     registry.Boolean(True, _("""Determines whether the bot will always prefix


### PR DESCRIPTION
Closes #654.