### PR TITLE
ShrinkUrl: Remove ln (Closes #618).

### DIFF
--- a/plugins/ShrinkUrl/config.py
+++ b/plugins/ShrinkUrl/config.py
@@ -42,8 +42,8 @@ def configure(advanced):
         conf.supybot.plugins.ShrinkUrl.shrinkSnarfer.setValue(True)
 
 class ShrinkService(registry.OnlySomeStrings):
-    """Valid values include 'ln', 'tiny', 'goo', 'ur1', and 'x0'."""
-    validStrings = ('ln', 'tiny', 'goo', 'ur1', 'x0')
+    """Valid values include 'tiny', 'goo', 'ur1', and 'x0'."""
+    validStrings = ('tiny', 'goo', 'ur1', 'x0')
 
 class ShrinkCycle(registry.SpaceSeparatedListOfStrings):
     """Valid values include 'ln', 'tiny', 'goo', 'ur1', and 'x0'."""
@@ -71,7 +71,7 @@ conf.registerChannelValue(ShrinkUrl, 'shrinkSnarfer',
     shrink snarfer is enabled.  This snarfer will watch for URLs in the
     channel, and if they're sufficiently long (as determined by
     supybot.plugins.ShrinkUrl.minimumLength) it will post a
-    smaller URL from either ln-s.net or tinyurl.com, as denoted in
+    smaller URL from tinyurl.com, as denoted in
     supybot.plugins.ShrinkUrl.default.""")))
 conf.registerChannelValue(ShrinkUrl.shrinkSnarfer, 'showDomain',
     registry.Boolean(True, _("""Determines whether the snarfer will show the

--- a/plugins/ShrinkUrl/plugin.py
+++ b/plugins/ShrinkUrl/plugin.py
@@ -172,37 +172,6 @@ class ShrinkUrl(callbacks.PluginRegexp):
     shrinkSnarfer.__doc__ = utils.web._httpUrlRe
 
     @retry
-    def _getLnUrl(self, url):
-        url = utils.web.urlquote(url)
-        try:
-            return self.db.get('ln', url)
-        except KeyError:
-            text = utils.web.getUrl('http://ln-s.net/home/api.jsp?url=' + url)
-            text = text.decode()
-            (code, text) = text.split(None, 1)
-            text = text.strip()
-            if code == '200':
-                self.db.set('ln', url, text)
-                return text
-            else:
-                raise ShrinkError(text)
-
-    @internationalizeDocstring
-    def ln(self, irc, msg, args, url):
-        """<url>
-
-        Returns an ln-s.net version of <url>.
-        """
-        try:
-            lnurl = self._getLnUrl(url)
-            m = irc.reply(lnurl)
-            if m is not None:
-                m.tag('shrunken')
-        except ShrinkError as e:
-            irc.error(str(e))
-    ln = thread(wrap(ln, ['httpUrl']))
-
-    @retry
     def _getTinyUrl(self, url):
         try:
             return self.db.get('tiny', url)

--- a/plugins/ShrinkUrl/test.py
+++ b/plugins/ShrinkUrl/test.py
@@ -39,8 +39,6 @@ class ShrinkUrlTestCase(ChannelPluginTestCase):
             'term=all+your+base+are+belong+to+us'
     tests = {'tiny': [(sfUrl, r'http://tinyurl.com/b7wyvfz'),
                       (udUrl, r'http://tinyurl.com/u479')],
-             'ln': [(sfUrl, r'http://ln-s.net/\+PE-'),
-                    (udUrl, r'http://ln-s.net/2\$K')],
              'goo': [(sfUrl, r'http://goo.gl/3c59N'),
                      (udUrl, r'http://goo.gl/ocTga')],
              'ur1': [(sfUrl, r'http://ur1.ca/9xl25'),
@@ -62,16 +60,14 @@ class ShrinkUrlTestCase(ChannelPluginTestCase):
             origsnarfer = snarfer()
             try:
                 self.assertNotError(
-                    'config plugins.ShrinkUrl.serviceRotation ln x0')
+                    'config plugins.ShrinkUrl.serviceRotation goo x0')
                 self.assertError(
-                    'config plugins.ShrinkUrl.serviceRotation ln x1')
+                    'config plugins.ShrinkUrl.serviceRotation goo x1')
                 snarfer.setValue(True)
                 self.assertSnarfRegexp(self.udUrl, r'.*%s.* \(at' %
-                                       self.tests['ln'][1][1])
+                                       self.tests['goo'][1][1])
                 self.assertSnarfRegexp(self.udUrl, r'.*%s.* \(at' %
                                        self.tests['x0'][1][1])
-                self.assertSnarfRegexp(self.udUrl, r'.*%s.* \(at' %
-                                       self.tests['ln'][1][1])
             finally:
                 cycle.setValue(origcycle)
                 snarfer.setValue(origsnarfer)
@@ -92,9 +88,6 @@ class ShrinkUrlTestCase(ChannelPluginTestCase):
 
         def testTinysnarf(self):
             self._snarf('tiny')
-
-        def testLnsnarf(self):
-            self._snarf('ln')
 
         def testGoosnarf(self):
             self._snarf('goo')


### PR DESCRIPTION
`ln-s.net` has been dead for over half a year now (#618); both their website homepage
and any previous shortened links return an HTTP 503. Thus, it isn't very
useful to leave this broken command lingering around...