### PR TITLE
Remove test from .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,2 @@
-test export-ignore
 sandbox export-ignore
 .git* export-ignore


### PR DESCRIPTION
Fixes an issue where tags/releases do not ship the core test suite, as used by the automated Travis testing.

Basically, every tag that has been made, when the tarballs are downloaded, they come without the test folder.
I thought that it would be useful to re-include this, as I'd like testing in my packages for versioned releases to mimic the test suite that Limnoria is running through travis.