### PR TITLE
[WARNING, BREAKS THINGS] Bind HTTPd to 0.0.0.0 & ::

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ install:
 # command to run tests, e.g. python setup.py test
 script:
   - echo $TRAVIS_PYTHON_VERSION
+  - sudo sysctl net.ipv6.bindv6only=1
   - python setup.py install
   - supybot-test test --plugins-dir=./build/lib*/supybot/plugins/ --no-network --disable-multiprocessing --exclude=./build/lib*/supybot/plugins/Scheduler --exclude=./build/lib*/supybot/plugins/Filter
 notifications:

--- a/src/conf.py
+++ b/src/conf.py
@@ -1151,10 +1151,10 @@ class IP(registry.String):
             registry.String.setValue(self, v)
 
 registerGlobalValue(supybot.servers.http, 'hosts4',
-    IP('', _("""Space-separated list of IPv4 hosts the HTTP server
+    IP('0.0.0.0', _("""Space-separated list of IPv4 hosts the HTTP server
     will bind.""")))
 registerGlobalValue(supybot.servers.http, 'hosts6',
-    IP('::0', _("""Space-separated list of IPv6 hosts the HTTP server will
+    IP('::', _("""Space-separated list of IPv6 hosts the HTTP server will
     bind.""")))
 registerGlobalValue(supybot.servers.http, 'port',
     registry.Integer(8080, _("""Determines what port the HTTP server will


### PR DESCRIPTION
This **BREAKS Limnoria's HTTPd** by default for users whose `net.ipv6.bindv6only` is not `1` (**(almost) everyone!**

Closes https://github.com/ProgVal/Supybot-plugins/issues/270
Closes https://github.com/ProgVal/Limnoria/issues/945