### PR TITLE
Channel: allow devoicing self

### DIFF
--- a/plugins/Channel/plugin.py
+++ b/plugins/Channel/plugin.py
@@ -259,10 +259,6 @@ class Channel(callbacks.Plugin):
         the nicks given.  If no nicks are given, removes voice from the person
         sending the message.
         """
-        if irc.nick in nicks:
-            irc.error(_('I cowardly refuse to devoice myself.  If you really '
-                      'want me devoiced, tell me to op you and then devoice '
-                      'me yourself.'), Raise=True)
         self._voice(irc, msg, args, channel, nicks, ircmsgs.devoices)
     devoice = wrap(devoice, ['channel', ('haveOp', 'devoice someone'),
                              any('nickInChannel')])

--- a/plugins/Channel/test.py
+++ b/plugins/Channel/test.py
@@ -103,9 +103,13 @@ class ChannelTestCase(ChannelPluginTestCase):
             self.irc.feedMsg(ircmsgs.deop(self.channel, self.nick))
 
     def testWontDeItself(self):
-        for s in 'deop dehalfop devoice'.split():
+        for s in 'deop dehalfop'.split():
             self.irc.feedMsg(ircmsgs.op(self.channel, self.nick))
             self.assertError('%s %s' % (s, self.nick))
+            
+    def testCanDevoiceSelf(self):
+        self.irc.feedMsg(ircmsgs.op(self.channel, self.nick))
+        self.assertNotError('devoice %s' % self.nick)
 
     def testOp(self):
         self.assertError('op')


### PR DESCRIPTION
Voice requires halfop or above to set, and since having (half)op gives greater access than voice, restricting this pretty useless.