### PR TITLE
Dict: add option to toggle showing which dictionaries responded to a query

### DIFF
--- a/plugins/Dict/config.py
+++ b/plugins/Dict/config.py
@@ -48,5 +48,9 @@ conf.registerChannelValue(Dict, 'default',
     registry.String('*', _("""Determines the default dictionary the bot
     will ask for definitions in.  If this value is '*' (without the quotes)
     the bot will use all dictionaries to define words.""")))
+conf.registerChannelValue(Dict, 'showWhichResponded',
+    registry.Boolean(True, _("""Determines whether the bot will show which
+    dictionaries responded to a query, if the selected dictionary is '*'.
+    """)))
 
 # vim:set shiftwidth=4 softtabstop=4 expandtab textwidth=79:

--- a/plugins/Dict/plugin.py
+++ b/plugins/Dict/plugin.py
@@ -122,7 +122,8 @@ class Dict(callbacks.Plugin):
             s = utils.str.normalizeWhitespace(s).rstrip(';.,')
             L.append('%s: %s' % (db, s))
         utils.sortBy(len, L)
-        if dictionary == '*' and len(dbs) > 1:
+        if dictionary == '*' and len(dbs) > 1 and \
+                self.registryValue("showWhichResponded", msg.args[0]):
             s = format(_('%L responded: %s'), list(dbs), '; '.join(L))
         else:
             s = '; '.join(L)


### PR DESCRIPTION
Dict's output is very long and verbose; this allows shortening it by a bit.