### PR TITLE
scripts/supybot: round total CPU time to 2 decimal places

### DIFF
--- a/scripts/supybot
+++ b/scripts/supybot
@@ -132,7 +132,7 @@ def main():
     seconds = now - world.startedAt
     log.info('Total uptime: %s.', utils.gen.timeElapsed(seconds))
     (user, system, _, _, _) = os.times()
-    log.info('Total CPU time taken: %s seconds.', user+system)
+    log.info('Total CPU time taken: %s seconds.', round(user+system, 2))
     log.info('No more Irc objects, exiting.')
 
 if __name__ == '__main__':

--- a/scripts/supybot
+++ b/scripts/supybot
@@ -132,7 +132,7 @@ def main():
     seconds = now - world.startedAt
     log.info('Total uptime: %s.', utils.gen.timeElapsed(seconds))
     (user, system, _, _, _) = os.times()
-    log.info('Total CPU time taken: %s seconds.', round(user+system, 2))
+    log.info('Total CPU time taken: %.2f seconds.', user+system)
     log.info('No more Irc objects, exiting.')
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is a stylistic change, which prevents things such as 0.9400000000001 seconds from showing up.