### PR TITLE
callbacks.py: log plugin name in registryValue='text' errors

### DIFF
--- a/src/callbacks.py
+++ b/src/callbacks.py
@@ -1358,7 +1358,8 @@ class PluginMixin(BasePlugin, irclib.IrcCallback):
             if ircutils.isChannel(channel):
                 group = group.get(channel)
             else:
-                self.log.debug('registryValue got channel=%r', channel)
+                self.log.debug('%s: registryValue got channel=%r', plugin,
+                               channel)
         if value:
             return group()
         else:


### PR DESCRIPTION
This can help with debugging to find what plugins are passing invalid things to `registryValue()`.