### PR TITLE
GPG version check

### DIFF
--- a/src/gpg.py
+++ b/src/gpg.py
@@ -71,19 +71,19 @@ for path in os.environ["PATH"].split(":"):
         gpgbin = "gpg"  # if it reaches this point, expect failures.
 
 gpgcheck0 = subprocess.Popen([gpgbin, "--version"],
-                             stdout=subprocess.PIPE).communicate()
-gpgcheck1 = gpgcheck0[0].decode("utf-8")
-gpgcheck2 = gpgcheck1.split()[2].split(".")
+                             stdout=subprocess.PIPE).communicate()[0]
+gpgcheck1 = gpgcheck0.decode("utf-8")
+gpgcheck = gpgcheck1.split()[2]
 
-if gpgcheck2[0] == "1" and gpgcheck2[1] == "4":
+if gpgcheck.startswith("1.4"):
     pubring = "pubring.gpg"
     secring = "secring.gpg"
     agent = "False"
-elif gpgcheck2[0] == "2" and gpgcheck2[1] == "0":
+elif gpgcheck.startswith("2.0"):
     pubring = "pubring.gpg"
     secring = "secring.gpg"
     agent = "True"
-elif gpgcheck2[0] == "2" and gpgcheck2[1] == "1":
+elif gpgcheck.startswith("2.1"):
     pubbox = "pubring.kbx"
     pubring = []  # GPG 2.1.x now hands the keyrings over to gpg-agent
     secring = []

--- a/src/gpg.py
+++ b/src/gpg.py
@@ -102,8 +102,8 @@ else:
                 gpgbin = "gpg2.exe"
             else:
                 gpgbin = "gpg"
-            except:
-                gpgbin = None
+        except:
+            gpgbin = None
 
 
 # It's not enough to just check for python-gnupg, it needs a backend:

--- a/src/gpg.py
+++ b/src/gpg.py
@@ -55,7 +55,9 @@ available = (gnupg is not None)
 # slightly.  Assuming gpg executable is in the path, may expand later
 # to check gor both gpg and gpg2.  Try to find GPG 1.4 first as it
 # will generally work more consistently on servers and is ideal for a
-# bot.
+# bot.  There may be unexpected results from setting "keyring" as a
+# global, but initial tests indicate it works - this cannot be
+# guaranteed, however.
 for path in os.environ["PATH"].split(":"):
     if os.path.exists(path + "/" + "gpg"):
         gpgbin = path + "/" + "gpg"
@@ -103,7 +105,7 @@ def fallback(default_return=None):
 
 @fallback()
 def loadKeyring():
-    global keyring  # this could be a problem since keyring is a gnupg parameter
+    global keyring
     path = os.path.abspath(conf.supybot.directories.data.dirize('GPGkeyring'))
     if not os.path.isdir(path):
         log.info('Creating directory %s' % path)

--- a/src/gpg.py
+++ b/src/gpg.py
@@ -69,14 +69,14 @@ if float(sys.version.split()[0][0:3]) >= 3.3:
     which = shutil.which
 else:
     import distutils.spawn
-    distutils.spawn.find_executable
+    which = distutils.spawn.find_executable
 
 if sys.platform == "win32":
     gpg1bin = which("gpg.exe")
     gpg2bin = which("gpg2.exe")
 else:
-    gpg1bin = shutil.which("gpg")
-    gpg2bin = shutil.which("gpg2")
+    gpg1bin = which("gpg")
+    gpg2bin = which("gpg2")
 
 if os.path.exists(gpg1bin):
     gpgbin = gpg1bin

--- a/src/gpg.py
+++ b/src/gpg.py
@@ -72,7 +72,7 @@ for path in os.environ["PATH"].split(":"):
 
 gpgcheck0 = subprocess.Popen([gpgbin, "--version"],
                              stdout=subprocess.PIPE).communicate()
-gpgcheck1 = gpgcheck[0].decode("utf-8")
+gpgcheck1 = gpgcheck0[0].decode("utf-8")
 gpgcheck2 = gpgcheck1.split()[2].split(".")
 
 if gpgcheck2[0] == "1" and gpgcheck2[1] == "4":

--- a/src/gpg.py
+++ b/src/gpg.py
@@ -129,6 +129,7 @@ elif gpgcheck.startswith("2.1"):
     secring = []
     agent = "True"
 
+
 def fallback(default_return=None):
     """Decorator.
     Does nothing if gnupg is loaded. Otherwise, returns the supplied
@@ -142,6 +143,7 @@ def fallback(default_return=None):
                 return default_return
         return newf
     return decorator
+
 
 @fallback()
 def loadKeyring():

--- a/src/gpg.py
+++ b/src/gpg.py
@@ -66,44 +66,30 @@ except TypeError:
 # avoided where possible.  It can be added later if there is demand.
 if float(sys.version.split()[0][0:3]) >= 3.3:
     import shutil
-    if sys.platform == "win32":
-        gpg1bin = shutil.which("gpg.exe")
-        gpg2bin = shutil.which("gpg2.exe")
-    else:
-        gpg1bin = shutil.which("gpg")
-        gpg2bin = shutil.which("gpg2")
-    if os.path.exists(gpg1bin):
-        gpgbin = gpg1bin
-    elif os.path.exists(gpg2bin):
-        gpgbin = gpg2bin
-    else:
-        try:
-            if sys.platform == "win32":
-                gpgbin = "gpg2.exe"
-            else:
-                gpgbin = "gpg"
-        except:
-            gpgbin = None
+    which = shutil.which
 else:
     import distutils.spawn
-    if sys.platform == "win32":
-        gpg1bin = distutils.spawn.find_executable("gpg.exe")
-        gpg2bin = distutils.spawn.find_executable("gpg2.exe")
-    else:
-        gpg1bin = distutils.spawn.find_executable("gpg")
-        gpg2bin = distutils.spawn.find_executable("gpg2")
-    if os.path.exists(gpg1bin):
-        gpgbin = gpg1bin
-    elif os.path.exists(gpg2bin):
-        gpgbin = gpg2bin
-    else:
-        try:
-            if sys.platform == "win32":
-                gpgbin = "gpg2.exe"
-            else:
-                gpgbin = "gpg"
-        except:
-            gpgbin = None
+    distutils.spawn.find_executable
+
+if sys.platform == "win32":
+    gpg1bin = which("gpg.exe")
+    gpg2bin = which("gpg2.exe")
+else:
+    gpg1bin = shutil.which("gpg")
+    gpg2bin = shutil.which("gpg2")
+
+if os.path.exists(gpg1bin):
+    gpgbin = gpg1bin
+elif os.path.exists(gpg2bin):
+    gpgbin = gpg2bin
+else:
+    try:
+        if sys.platform == "win32":
+            gpgbin = "gpg2.exe"
+        else:
+            gpgbin = "gpg"
+    except:
+        gpgbin = None
 
 
 # It's not enough to just check for python-gnupg, it needs a backend:

--- a/src/gpg.py
+++ b/src/gpg.py
@@ -64,7 +64,9 @@ except TypeError:
 # however, would result in a significant delay in loading times
 # (depending on the size of the filesystem) and, ideally should be
 # avoided where possible.  It can be added later if there is demand.
-if float(sys.version.split()[0][0:3]) >= 3.3:
+svi = sys.version_info
+
+if float("{0}.{1}".format(svi[0], svi[1])) >= 3.3:
     import shutil
     which = shutil.which
 else:


### PR DESCRIPTION
With the release of GPG 2.1.x as stable (relatively, there are still issues with it), it is now possible for legitimate, but conflicting gnupg.py configuration to be required.  This patch locates the GPG executable on a system (in the $PATH) and determines which series of GPG it is (1.4.x, 2.0.x or 2.1.x) and then sets the variables required by gnupg.py accordingly.

Though it checks for gpg.exe (as in gpg4usb) and gpg2.exe (as in gpg4win), there has been no Windows testing and there is no indication that it will work (it may not due to the reliance on $PATH).

Minimal testing indicates there is not, as was first suspected, a conflict between the keyring global set in src/gpg.py and the keyring value specified when gnupg.GPG is called.  There are, however, no guarantees that this will always be the case or that it will prove true under all scenarios.

Please note the **major** changes in GPG 2.1.x which include handing control of the keyrings over to gpg-agent and changing the public keyring format.  While this code presently favours the GPG 1.4.x series, which is still the most common on POSIX systems, this must be temporary.  The reason being that a migration to ECC keys over the next few years will occur and the ECC code in the more recent GPG series will **not** be backported to GPG 1.4.x.  Additionally, the current standard for OpenPGP, RFC 4880, is currently under review with the aim to release a new OpenPGP RFC in anticipation of the ECC migration.  The new RFC **will** deprecate a number of functions and algorithms in GPG 1.4.x.

This definitely requires additional testing before merging with master, but it is based on existing code I've been running with GPG 1.4.19 and 2.1.3.  It should theoretically work without trouble and is not complex.
