### PR TITLE
Revert "Improve order of connect messages." (SASL fix on freenode)

### DIFF
--- a/src/irclib.py
+++ b/src/irclib.py
@@ -956,22 +956,6 @@ class Irc(IrcCommandDispatcher):
 
             return
 
-        if self.password:
-            log.info('%s: Queuing PASS command, not logging the password.',
-                     self.network)
-
-            self.sendMsg(ircmsgs.password(self.password))
-
-        log.debug('%s: Sending NICK command, nick is %s.',
-                  self.network, self.nick)
-
-        self.sendMsg(ircmsgs.nick(self.nick))
-
-        log.debug('%s: Sending USER command, ident is %s, user is %s.',
-                  self.network, self.ident, self.user)
-
-        self.sendMsg(ircmsgs.user(self.ident, self.user))
-
         self.sasl = None
 
         if ecdsa and self.sasl_username and self.sasl_ecdsa_key:
@@ -995,6 +979,22 @@ class Irc(IrcCommandDispatcher):
             self.sendMsg(ircmsgs.IrcMsg(command='CAP', args=('REQ', 'sasl')))
         else:
             self.sendMsg(ircmsgs.IrcMsg(command='CAP', args=('END',)))
+
+        if self.password:
+            log.info('%s: Queuing PASS command, not logging the password.',
+                     self.network)
+
+            self.sendMsg(ircmsgs.password(self.password))
+
+        log.debug('%s: Queuing NICK command, nick is %s.',
+                  self.network, self.nick)
+
+        self.sendMsg(ircmsgs.nick(self.nick))
+
+        log.debug('%s: Queuing USER command, ident is %s, user is %s.',
+                  self.network, self.ident, self.user)
+
+        self.sendMsg(ircmsgs.user(self.ident, self.user))
 
     def doAuthenticate(self, msg):
         if len(msg.args) == 1 and msg.args[0] == '+':

--- a/test/test_irclib.py
+++ b/test/test_irclib.py
@@ -383,19 +383,19 @@ class IrcTestCase(SupyTestCase):
         m = self.irc.takeMsg()
         self.failUnless(m.command == 'NICK', 'Expected NICK, got %r.' % m)
         m = self.irc.takeMsg()
+        self.failUnless(m.command == 'CAP', 'Expected CAP, got %r.' % m)
+        m = self.irc.takeMsg()
+        self.failUnless(m.command == 'CAP', 'Expected CAP, got %r.' % m)
+        m = self.irc.takeMsg()
+        self.failUnless(m.command == 'CAP', 'Expected CAP, got %r.' % m)
+        m = self.irc.takeMsg()
+        self.failUnless(m.command == 'CAP', 'Expected CAP, got %r.' % m)
+        m = self.irc.takeMsg()
+        self.failUnless(m.command == 'CAP', 'Expected CAP, got %r.' % m)
+        m = self.irc.takeMsg()
+        self.failUnless(m.command == 'CAP', 'Expected CAP, got %r.' % m)
+        m = self.irc.takeMsg()
         self.failUnless(m.command == 'USER', 'Expected USER, got %r.' % m)
-        m = self.irc.takeMsg()
-        self.failUnless(m.command == 'CAP', 'Expected CAP, got %r.' % m)
-        m = self.irc.takeMsg()
-        self.failUnless(m.command == 'CAP', 'Expected CAP, got %r.' % m)
-        m = self.irc.takeMsg()
-        self.failUnless(m.command == 'CAP', 'Expected CAP, got %r.' % m)
-        m = self.irc.takeMsg()
-        self.failUnless(m.command == 'CAP', 'Expected CAP, got %r.' % m)
-        m = self.irc.takeMsg()
-        self.failUnless(m.command == 'CAP', 'Expected CAP, got %r.' % m)
-        m = self.irc.takeMsg()
-        self.failUnless(m.command == 'CAP', 'Expected CAP, got %r.' % m)
 
     def testPingResponse(self):
         self.irc.feedMsg(ircmsgs.ping('123'))
@@ -435,6 +435,7 @@ class IrcTestCase(SupyTestCase):
             except:
                 pass
         self.irc.reset()
+        self.failIf(self.irc.fastqueue)
         self.failIf(self.irc.state.history)
         self.failIf(self.irc.state.channels)
         self.failIf(self.irc.outstandingPing)
@@ -492,13 +493,13 @@ class IrcCallbackTestCase(SupyTestCase):
             conf.supybot.user.setValue(user)
             expected = [
                 ircmsgs.nick(nick),
-                ircmsgs.user('limnoria', user),
                 ircmsgs.IrcMsg(command='CAP', args=('REQ', 'account-notify')),
                 ircmsgs.IrcMsg(command='CAP', args=('REQ', 'extended-join')),
                 ircmsgs.IrcMsg(command='CAP', args=('REQ', 'multi-prefix')),
                 ircmsgs.IrcMsg(command='CAP', args=('REQ', 'metadata-notify')),
                 ircmsgs.IrcMsg(command='CAP', args=('REQ', 'account-tag')),
                 ircmsgs.IrcMsg(command='CAP', args=('END',)),
+                ircmsgs.user('limnoria', user)
             ]
             irc = irclib.Irc('test')
             msgs = [irc.takeMsg()]

--- a/test/test_irclib.py
+++ b/test/test_irclib.py
@@ -381,19 +381,19 @@ class IrcTestCase(SupyTestCase):
         #m = self.irc.takeMsg()
         #self.failUnless(m.command == 'PASS', 'Expected PASS, got %r.' % m)
         m = self.irc.takeMsg()
+        self.failUnless(m.command == 'CAP', 'Expected CAP, got %r.' % m)
+        m = self.irc.takeMsg()
+        self.failUnless(m.command == 'CAP', 'Expected CAP, got %r.' % m)
+        m = self.irc.takeMsg()
+        self.failUnless(m.command == 'CAP', 'Expected CAP, got %r.' % m)
+        m = self.irc.takeMsg()
+        self.failUnless(m.command == 'CAP', 'Expected CAP, got %r.' % m)
+        m = self.irc.takeMsg()
+        self.failUnless(m.command == 'CAP', 'Expected CAP, got %r.' % m)
+        m = self.irc.takeMsg()
+        self.failUnless(m.command == 'CAP', 'Expected CAP, got %r.' % m)
+        m = self.irc.takeMsg()
         self.failUnless(m.command == 'NICK', 'Expected NICK, got %r.' % m)
-        m = self.irc.takeMsg()
-        self.failUnless(m.command == 'CAP', 'Expected CAP, got %r.' % m)
-        m = self.irc.takeMsg()
-        self.failUnless(m.command == 'CAP', 'Expected CAP, got %r.' % m)
-        m = self.irc.takeMsg()
-        self.failUnless(m.command == 'CAP', 'Expected CAP, got %r.' % m)
-        m = self.irc.takeMsg()
-        self.failUnless(m.command == 'CAP', 'Expected CAP, got %r.' % m)
-        m = self.irc.takeMsg()
-        self.failUnless(m.command == 'CAP', 'Expected CAP, got %r.' % m)
-        m = self.irc.takeMsg()
-        self.failUnless(m.command == 'CAP', 'Expected CAP, got %r.' % m)
         m = self.irc.takeMsg()
         self.failUnless(m.command == 'USER', 'Expected USER, got %r.' % m)
 
@@ -435,7 +435,6 @@ class IrcTestCase(SupyTestCase):
             except:
                 pass
         self.irc.reset()
-        self.failIf(self.irc.fastqueue)
         self.failIf(self.irc.state.history)
         self.failIf(self.irc.state.channels)
         self.failIf(self.irc.outstandingPing)
@@ -492,14 +491,14 @@ class IrcCallbackTestCase(SupyTestCase):
             user = 'user any user'
             conf.supybot.user.setValue(user)
             expected = [
-                ircmsgs.nick(nick),
                 ircmsgs.IrcMsg(command='CAP', args=('REQ', 'account-notify')),
                 ircmsgs.IrcMsg(command='CAP', args=('REQ', 'extended-join')),
                 ircmsgs.IrcMsg(command='CAP', args=('REQ', 'multi-prefix')),
                 ircmsgs.IrcMsg(command='CAP', args=('REQ', 'metadata-notify')),
                 ircmsgs.IrcMsg(command='CAP', args=('REQ', 'account-tag')),
                 ircmsgs.IrcMsg(command='CAP', args=('END',)),
-                ircmsgs.user('limnoria', user)
+                ircmsgs.nick(nick),
+                ircmsgs.user('limnoria', user),
             ]
             irc = irclib.Irc('test')
             msgs = [irc.takeMsg()]


### PR DESCRIPTION
This reverts commit a2004b7150bde2c6c89d088e7e16fd7dcea38b50.

I want to revert this change because it caused SASL to fail for me on at least Freenode. The issue stems, I believe, from `CAP` being requested *after* initial signon: A fast responding server would have connected the bot as a regular user before it gets a chance to identify via SASL. Instead, it simply throws this error, basically stating that connected users can't use SASL.

`ERROR 2015-05-21T17:39:13 Unhandled error message from server: IrcMsg(prefix="holmes.freenode.net", command="462", args=('firehazard', 'You may not reregister'))`