### PR TITLE
Add missing future imports for print_function

### DIFF
--- a/plugins/Math/test.py
+++ b/plugins/Math/test.py
@@ -28,6 +28,8 @@
 # POSSIBILITY OF SUCH DAMAGE.
 ###
 
+from __future__ import print_function
+
 from supybot.test import *
 
 class MathTestCase(PluginTestCase):

--- a/plugins/News/test.py
+++ b/plugins/News/test.py
@@ -27,6 +27,8 @@
 # POSSIBILITY OF SUCH DAMAGE.
 ###
 
+from __future__ import print_function
+
 import time
 
 from supybot.test import *

--- a/scripts/supybot-plugin-create
+++ b/scripts/supybot-plugin-create
@@ -30,6 +30,8 @@
 # POSSIBILITY OF SUCH DAMAGE.
 ###
 
+from __future__ import print_function
+
 import supybot
 
 import os

--- a/scripts/supybot-wizard
+++ b/scripts/supybot-wizard
@@ -30,6 +30,8 @@
 # POSSIBILITY OF SUCH DAMAGE.
 ###
 
+from __future__ import print_function
+
 import os
 import sys
 


### PR DESCRIPTION
There are some places where `print()` is used to print a blank line. However, unless the future feature `print_function` is imported, that will print `()` in Python 2.