### PR TITLE
irclib: fix error when SASL is supported but not enabled for a network

### DIFF
--- a/src/irclib.py
+++ b/src/irclib.py
@@ -1040,7 +1040,7 @@ class Irc(IrcCommandDispatcher):
                  self.network, caps)
         self.state.capabilities_ack.update(caps)
 
-        if 'sasl' in caps:
+        if 'sasl' in caps and self.sasl:
             self.sendMsg(ircmsgs.IrcMsg(command='AUTHENTICATE', args=(self.sasl.upper(),)))
         else:
             self.sendMsg(ircmsgs.IrcMsg(command='CAP', args=('END',)))


### PR DESCRIPTION
This fixes a regression introduced by #1122, when SASL is supported on a network but isn't configured/being used. This bug would've caused connections to fail and time out on these networks:

```
INFO 2015-06-12T17:42:59 espernet: Server acknowledged capabilities: account-notify extended-join multi-prefix sasl
ERROR 2015-06-12T17:42:59 Uncaught exception in Irc.feedMsg:
Traceback (most recent call last):
  File "/home/gl/.local/lib/python3.4/site-packages/supybot/log.py", line 361, in m
    return f(self, *args, **kwargs)
  File "/home/gl/.local/lib/python3.4/site-packages/supybot/irclib.py", line 860, in feedMsg
    method(msg)
  File "/home/gl/.local/lib/python3.4/site-packages/supybot/irclib.py", line 1042, in doCap
    self.doCapAck(msg)
  File "/home/gl/.local/lib/python3.4/site-packages/supybot/irclib.py", line 1057, in doCapAck
    self.sendMsg(ircmsgs.IrcMsg(command='AUTHENTICATE', args=(self.sasl.upper(),)))
AttributeError: 'NoneType' object has no attribute 'upper'
ERROR 2015-06-12T17:42:59 Exception id: 0x5a0dc
WARNING 2015-06-12T17:43:35 Error message from espernet: Closing Link: millennium.overdrive.pw (Connection timed out)
```