### PR TITLE
fix: remove line break in IRC message

### DIFF
--- a/plugins/RSS/plugin.py
+++ b/plugins/RSS/plugin.py
@@ -371,6 +371,8 @@ class RSS(callbacks.Plugin):
             template = self.registryValue(key_name, channel)
         date = entry.get('published_parsed')
         date = utils.str.timestamp(date)
+        if entry and entry.title: # for single line msg
+            entry['title'] = entry.title.replace("\n"," ");
         return string.Template(template).safe_substitute(
                 feed_name=feed.name,
                 date=date,


### PR DESCRIPTION
This prevent ircutils.isValidArgument assertion

Can be tested using this feed :
http://net3d.free.fr/tmp/2015/2015-06-18/index.rss

Signed-off-by: Philippe Coval <rzr@gna.org>