### PR TITLE
conf.py: raise protocols.http.peeksize to 8192

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -1125,7 +1125,7 @@ registerGlobalValue(supybot.protocols.irc.queuing.rateLimit, 'join',
 ###
 registerGroup(supybot.protocols, 'http')
 registerGlobalValue(supybot.protocols.http, 'peekSize',
-    registry.PositiveInteger(4096, _("""Determines how many bytes the bot will
+    registry.PositiveInteger(8192, _("""Determines how many bytes the bot will
     'peek' at when looking through a URL for a doctype or title or something
     similar.  It'll give up after it reads this many bytes, even if it hasn't
     found what it was looking for.""")))


### PR DESCRIPTION
YouTube (as an example) has recently updated its site design again so the `<title>` element falls right out of the 4K mark, causing YouTube links to be ignored. This commit raises the default peeksize to 8K, which allows title snarfing to work again.

The difference between 4 and 8 kilobytes isn't that big, so I don't think this change would do any harm.