### PR TITLE
Allow unregistered users to use 'add', 'remove', etc. in ChannelIdDatabasePlugin plugins

### DIFF
--- a/plugins/Praise/test.py
+++ b/plugins/Praise/test.py
@@ -29,7 +29,7 @@
 
 from supybot.test import *
 
-class PraiseTestCase(PluginTestCase):
+class PraiseTestCase(ChannelPluginTestCase):
     plugins = ('Praise',)
     
     def testAdd(self):

--- a/plugins/Quote/test.py
+++ b/plugins/Quote/test.py
@@ -40,4 +40,16 @@ class QuoteTestCase(ChannelPluginTestCase):
         self.assertRegexp("quote get 1", "goodbye")
         self.assertError("quote replace 5 afsdafas") # non-existant
 
+    def testUnauthenticatedAdd(self):
+        # This should fail because the user isn't registered
+        self.assertError('quote add hello world!')
+        original_value = conf.supybot.databases.plugins.requireRegistration()
+        conf.supybot.databases.plugins.requireRegistration.setValue(False)
+        try:
+            self.assertNotError('quote add hello world!')
+            self.assertRegexp('quote get 1', 'hello')
+            self.assertNotError('quote remove 1')
+        finally:
+            conf.supybot.databases.plugins.requireRegistration.setValue(original_value)
+
 # vim:set shiftwidth=4 softtabstop=4 expandtab textwidth=79:

--- a/plugins/Quote/test.py
+++ b/plugins/Quote/test.py
@@ -43,13 +43,9 @@ class QuoteTestCase(ChannelPluginTestCase):
     def testUnauthenticatedAdd(self):
         # This should fail because the user isn't registered
         self.assertError('quote add hello world!')
-        original_value = conf.supybot.databases.plugins.requireRegistration()
-        conf.supybot.databases.plugins.requireRegistration.setValue(False)
-        try:
+        with conf.supybot.databases.plugins.requireRegistration.context(False):
             self.assertNotError('quote add hello world!')
             self.assertRegexp('quote get 1', 'hello')
             self.assertNotError('quote remove 1')
-        finally:
-            conf.supybot.databases.plugins.requireRegistration.setValue(original_value)
 
 # vim:set shiftwidth=4 softtabstop=4 expandtab textwidth=79:

--- a/src/conf.py
+++ b/src/conf.py
@@ -932,7 +932,7 @@ class ChannelSpecific(registry.Boolean):
 
 registerGroup(supybot.databases, 'plugins')
 
-registerGlobalValue(supybot.databases.plugins, 'requireRegistration',
+registerChannelValue(supybot.databases.plugins, 'requireRegistration',
     registry.Boolean(True, _("""Determines whether the bot will require user
     registration to use 'add' commands in database-based Supybot
     plugins.""")))

--- a/src/conf.py
+++ b/src/conf.py
@@ -931,6 +931,11 @@ class ChannelSpecific(registry.Boolean):
         return lchannel
 
 registerGroup(supybot.databases, 'plugins')
+
+registerGlobalValue(supybot.databases.plugins, 'requireRegistration',
+    registry.Boolean(True, _("""Determines whether the bot will require user
+    registration to use 'add' commands in database-based Supybot
+    plugins.""")))
 registerChannelValue(supybot.databases.plugins, 'channelSpecific',
     ChannelSpecific(True, _("""Determines whether database-based plugins that
     can be channel-specific will be so.  This can be overridden by individual


### PR DESCRIPTION
This adds a new configuration variable, `supybot.databases.plugins.requireRegistration`, which defaults to `True` for maximum security. When this is disabled, unauthenticated users will be able to use commands such as `quote add` freely. This is really my rationale for this, as most IRC quote bots I know of don't require registration, and people didn't like how Supybot forced registration for adding quotes.

Internally, this allows storing a string (hostmask) where the user ID (integer) usually goes, and `checkChangeAllowed` will `return True` if the hostmask of the caller matches the hostmask stored.

I also fixed Praise's tests by making them channel specific. (Travis CI pointed this out during building)
