### PR TITLE
ircutils.formatWhois: ignore channels that have +p set

### DIFF
--- a/src/ircutils.py
+++ b/src/ircutils.py
@@ -434,7 +434,7 @@ def formatWhois(irc, replies, caller='', channel='', command='whois'):
                     continue
                 # Skip +s/+p channels the target is in only if the reply isn't
                 # being sent to that channel.
-                if {'s', 'p'} & set(chanState.modes.keys()) and \
+                if set(('p', 's')) & set(chanState.modes.keys()) and \
                    not strEqual(channel or '', chan):
                     continue
             if not modes:

--- a/src/ircutils.py
+++ b/src/ircutils.py
@@ -432,9 +432,9 @@ def formatWhois(irc, replies, caller='', channel='', command='whois'):
                 # target is +i.
                 if caller not in chanState.users:
                     continue
-                # Skip +s channels the target is in only if the reply isn't
+                # Skip +s/+p channels the target is in only if the reply isn't
                 # being sent to that channel.
-                if 's' in chanState.modes and \
+                if {'s', 'p'} & set(chanState.modes.keys()) and \
                    not strEqual(channel or '', chan):
                     continue
             if not modes:


### PR DESCRIPTION
Fixes #98: see https://github.com/ProgVal/Limnoria/issues/98#issuecomment-121519435. The case of hiding channels for umode `+i` *isn't standard across IRCds*, so I don't think implementing it would be correct.