### PR TITLE
httpserver.py: Pass Content-Length to read call

### DIFF
--- a/src/httpserver.py
+++ b/src/httpserver.py
@@ -246,7 +246,8 @@ class SupyHTTPRequestHandler(BaseHTTPRequestHandler):
                          'CONTENT_TYPE':self.headers['Content-Type'],
                          })
         else:
-            form = self.rfile.read()
+            content_length = int(self.headers.get('Content-Length', '0'))
+            form = self.rfile.read(content_length)
         self.do_X('doPost', form=form)
 
     def do_HEAD(self):


### PR DESCRIPTION
If a POST request is sent to the built-in http server the handling function does not terminate because the rfile.read() function blocks.

This patch passes the Content-Length value to the self.rfile.read() function that is required for it to do not block the method.

Regarding [RFC 2616](http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.4) the Content-Length header is expected to be sent otherwise this patch assumes a zero length.