### PR TITLE
Add support for italic formatting

### DIFF
--- a/src/ircutils.py
+++ b/src/ircutils.py
@@ -299,6 +299,10 @@ def bold(s):
     """Returns the string s, bolded."""
     return '\x02%s\x02' % s
 
+def italic(s):
+    """Returns the string s, italicised."""
+    return '\x1D%s\x1D' % s
+
 def reverse(s):
     """Returns the string s, reverse-videoed."""
     return '\x16%s\x16' % s
@@ -355,6 +359,10 @@ def stripBold(s):
     """Returns the string s, with bold removed."""
     return s.replace('\x02', '')
 
+def stripItalic(s):
+    """Returns the string s, with italics removed."""
+    return s.replace('\x1d', '')
+
 _stripColorRe = re.compile(r'\x03(?:\d{1,2},\d{1,2}|\d{1,2}|,\d{1,2}|)')
 def stripColor(s):
     """Returns the string s, with color removed."""
@@ -375,6 +383,7 @@ def stripFormatting(s):
     s = stripBold(s)
     s = stripReverse(s)
     s = stripUnderline(s)
+    s = stripItalic(s)
     return s.replace('\x0f', '').replace('\x0F', '')
 
 _containsFormattingRe = re.compile(r'[\x02\x03\x16\x1f]')

--- a/test/test_ircutils.py
+++ b/test/test_ircutils.py
@@ -92,6 +92,11 @@ class FunctionsTestCase(SupyTestCase):
         self.assertEqual(s[0], '\x02')
         self.assertEqual(s[-1], '\x02')
 
+    def testItalic(self):
+        s = ircutils.italic('foo')
+        self.assertEqual(s[0], '\x1d')
+        self.assertEqual(s[-1], '\x1d')
+
     def testUnderline(self):
         s = ircutils.underline('foo')
         self.assertEqual(s[0], '\x1f')
@@ -126,6 +131,9 @@ class FunctionsTestCase(SupyTestCase):
     def testStripBold(self):
         self.assertEqual(ircutils.stripBold(ircutils.bold('foo')), 'foo')
 
+    def testStripItalic(self):
+        self.assertEqual(ircutils.stripItalic(ircutils.italic('foo')), 'foo')
+
     def testStripColor(self):
         self.assertEqual(ircutils.stripColor('\x02bold\x0302,04foo\x03bar\x0f'),
                          '\x02boldfoobar\x0f')
@@ -149,6 +157,7 @@ class FunctionsTestCase(SupyTestCase):
 
     def testStripFormatting(self):
         self.assertEqual(ircutils.stripFormatting(ircutils.bold('foo')), 'foo')
+        self.assertEqual(ircutils.stripFormatting(ircutils.italic('foo')), 'foo')
         self.assertEqual(ircutils.stripFormatting(ircutils.reverse('foo')),
                          'foo')
         self.assertEqual(ircutils.stripFormatting(ircutils.underline('foo')),


### PR DESCRIPTION
New functions:
ircutils.italic to add
ircutils.stripItalic to remove

And remove italics in ircutils.stripFormatting.