### PR TITLE
Alias improvements

### DIFF
--- a/plugins/Alias/config.py
+++ b/plugins/Alias/config.py
@@ -44,6 +44,6 @@ Alias = conf.registerPlugin('Alias')
 conf.registerGroup(Alias, 'aliases')
 conf.registerGroup(Alias, 'escapedaliases')
 conf.registerGlobalValue(Alias, 'validName',
-    registry.String(r'^[a-z.|!?][a-z0-9.|!]*$', _("""Regex which alias names must match in order to be valid""")))
+    registry.String(r'^[^\x00-\x20]+$', _("""Regex which alias names must match in order to be valid""")))
 
 # vim:set shiftwidth=4 softtabstop=4 expandtab textwidth=79:

--- a/plugins/Alias/config.py
+++ b/plugins/Alias/config.py
@@ -43,5 +43,7 @@ def configure(advanced):
 Alias = conf.registerPlugin('Alias')
 conf.registerGroup(Alias, 'aliases')
 conf.registerGroup(Alias, 'escapedaliases')
+conf.registerGlobalValue(Alias, 'validName',
+    registry.String(r'^[a-z.|!?][a-z0-9.|!]*$', _("""Regex which alias names must match in order to be valid""")))
 
 # vim:set shiftwidth=4 softtabstop=4 expandtab textwidth=79:

--- a/plugins/Alias/plugin.py
+++ b/plugins/Alias/plugin.py
@@ -336,13 +336,9 @@ class Alias(callbacks.Plugin):
             irc.error(_('There is no such alias.'))
     unlock = wrap(unlock, [('checkCapability', 'admin'), 'commandName'])
 
-    _validNameRe = re.compile(r'^[a-z.|!?][a-z0-9.|!]*$')
     def addAlias(self, irc, name, alias, lock=False):
-        if not self._validNameRe.search(name):
-            raise AliasError('Names can only contain alphanumerical '
-                    'characters, dots, pipes, and '
-                    'exclamation/interrogatin marks '
-                    '(and the first character cannot be a number).')
+        if not re.search(self.registryValue('validName'), name):
+            raise AliasError('Invalid alias name.')
         realName = callbacks.canonicalName(name)
         if name != realName:
             s = format(_('That name isn\'t valid.  Try %q instead.'), realName)

--- a/plugins/Alias/plugin.py
+++ b/plugins/Alias/plugin.py
@@ -319,9 +319,16 @@ class Alias(callbacks.Plugin):
             group.unregister(name)
 
 
-    def setLocked(name, value):
+    def setLocked(self, name, value):
         self.aliases[name][1] = value
         self.aliasRegistryNode(name).locked.setValue(value)
+
+    def isValidName(self, name):
+        if not re.search(self.registryValue('validName'), name):
+            return False
+        if not registry.isValidRegistryName(name):
+            return False
+        return True
 
     @internationalizeDocstring
     def lock(self, irc, msg, args, name):
@@ -350,7 +357,7 @@ class Alias(callbacks.Plugin):
     unlock = wrap(unlock, [('checkCapability', 'admin'), 'commandName'])
 
     def addAlias(self, irc, name, alias, lock=False):
-        if not re.search(self.registryValue('validName'), name):
+        if not self.isValidName(name):
             raise AliasError('Invalid alias name.')
         realName = callbacks.canonicalName(name)
         if name != realName:

--- a/plugins/Alias/plugin.py
+++ b/plugins/Alias/plugin.py
@@ -272,7 +272,7 @@ class Alias(callbacks.Plugin):
             command = value()
             locked = value.locked()
             self.aliases[unescapeAlias(name)] = [command, locked, None]
-        for (alias, (command, locked, _)) in self.aliases.items():
+        for (alias, (command, locked, _)) in self.aliases.copy().items():
             try:
                 self.addAlias(irc, alias, command, locked)
             except Exception as e:

--- a/plugins/Alias/plugin.py
+++ b/plugins/Alias/plugin.py
@@ -425,6 +425,36 @@ class Alias(callbacks.Plugin):
             irc.error(str(e))
     remove = wrap(remove, ['commandName'])
 
+    @internationalizeDocstring
+    def list(self, irc, msg, args, optlist):
+        """[--{locked,unlocked}]
+
+        Lists alias names of a particular type, defaults to all aliases if no
+        --locked or --unlocked option is given.
+        """
+        optlist = dict(optlist)
+        if len(optlist)>1:
+            irc.error(_('Cannot specify --locked and --unlocked simultaneously'))
+            return
+        aliases = []
+        for name in self.aliases.keys():
+            if self.isCommandMethod(name):
+                if 'locked' in optlist:
+                    if self.aliases[name][1]: aliases.append(name)
+                elif 'unlocked' in optlist:
+                    if not self.aliases[name][1]: aliases.append(name)
+                else:
+                    aliases.append(name)
+        if aliases:
+            aliases.sort()
+            irc.reply(format('%L', aliases))
+        else:
+            if len(optlist):
+                irc.reply(_('There are no aliases of that type.'))
+            else:
+                irc.reply(_('There are no aliases.'))
+    list = wrap(list, [getopts({'locked':'', 'unlocked':''})])
+
 
 Class = Alias
 

--- a/plugins/Alias/plugin.py
+++ b/plugins/Alias/plugin.py
@@ -431,7 +431,7 @@ class Alias(callbacks.Plugin):
 
     @internationalizeDocstring
     def list(self, irc, msg, args, optlist):
-        """[--{locked,unlocked}]
+        """[--locked|--unlocked]
 
         Lists alias names of a particular type, defaults to all aliases if no
         --locked or --unlocked option is given.

--- a/plugins/Alias/plugin.py
+++ b/plugins/Alias/plugin.py
@@ -303,7 +303,12 @@ class Alias(callbacks.Plugin):
         """
         if name in self.aliases and self.isCommandMethod(name):
             self.aliases[name][1] = True
-            conf.supybot.plugins.Alias.aliases.get(name).locked.setValue(True)
+            if (needsEscaping(name)):
+                group = conf.supybot.plugins.Alias.escapedaliases
+                name = escapeAlias(name)
+            else:
+                group = conf.supybot.plugins.Alias.aliases
+            group.get(name).locked.setValue(True)
             irc.replySuccess()
         else:
             irc.error(_('There is no such alias.'))
@@ -317,7 +322,12 @@ class Alias(callbacks.Plugin):
         """
         if name in self.aliases and self.isCommandMethod(name):
             self.aliases[name][1] = False
-            conf.supybot.plugins.Alias.aliases.get(name).locked.setValue(False)
+            if (needsEscaping(name)):
+                group = conf.supybot.plugins.Alias.escapedaliases
+                name = escapeAlias(name)
+            else:
+                group = conf.supybot.plugins.Alias.aliases
+            group.get(name).locked.setValue(False)
             irc.replySuccess()
         else:
             irc.error(_('There is no such alias.'))

--- a/plugins/Alias/test.py
+++ b/plugins/Alias/test.py
@@ -33,6 +33,7 @@ from supybot.test import *
 import supybot.conf as conf
 import supybot.plugin as plugin
 import supybot.registry as registry
+from supybot.utils.minisix import u
 
 from . import plugin as Alias
 
@@ -128,11 +129,11 @@ class AliasTestCase(ChannelPluginTestCase):
         self.assertResponse('myre foo bar', 's/foo/bar/g')
 
     def testUnicode(self):
-        self.assertNotError(u'alias add \u200b echo foo')
-        self.assertResponse(u'\u200b', 'foo')
+        self.assertNotError(u('alias add \u200b echo foo'))
+        self.assertResponse(u('\u200b'), 'foo')
 
-        self.assertNotError(u'alias add café echo bar')
-        self.assertResponse(u'café', 'bar')
+        self.assertNotError('alias add café echo bar')
+        self.assertResponse('café', 'bar')
 
     def testSimpleAliasWithoutArgsImpliesDollarStar(self):
         self.assertNotError('alias add exo echo')

--- a/plugins/Alias/test.py
+++ b/plugins/Alias/test.py
@@ -127,6 +127,13 @@ class AliasTestCase(ChannelPluginTestCase):
         self.assertNotError('alias add myre "echo s/$1/$2/g"')
         self.assertResponse('myre foo bar', 's/foo/bar/g')
 
+    def testUnicode(self):
+        self.assertNotError(u'alias add \u200b echo foo')
+        self.assertResponse(u'\u200b', 'foo')
+
+        self.assertNotError(u'alias add café echo bar')
+        self.assertResponse(u'café', 'bar')
+
     def testSimpleAliasWithoutArgsImpliesDollarStar(self):
         self.assertNotError('alias add exo echo')
         self.assertResponse('exo foo bar baz', 'foo bar baz')

--- a/plugins/Alias/test.py
+++ b/plugins/Alias/test.py
@@ -112,8 +112,7 @@ class AliasTestCase(ChannelPluginTestCase):
         self.failIf('foobar' in cb.aliases)
         self.assertError('foobar')
 
-        self.assertRegexp('alias add café ignore', 'Error.*can only contain')
-        self.assertRegexp('alias add 1abc ignore', 'Error.*can only contain')
+        self.assertRegexp('alias add abc\x07 ignore', 'Error.*Invalid')
 
     def testOptionalArgs(self):
         self.assertNotError('alias add myrepr "repr @1"')


### PR DESCRIPTION
711572b and fd53d8c are bugfixes.
54e9b4b - new feature, Alias.list command to list alias names, optionally filtered by --locked or --unlocked.
963a17c - new config option to allow relaxing the rules on alias names
d9b21dc (optional) - change default value for the new config option to a more relaxed one

I'm not sure what, if anything, needs doing about internationalisation and messages.pot though...