### PR TITLE
Send User.list response in private

### DIFF
--- a/plugins/User/config.py
+++ b/plugins/User/config.py
@@ -43,7 +43,7 @@ def configure(advanced):
 
 
 User = conf.registerPlugin('User')
-conf.registerGlobalValue(User, 'listInPrivate',
+conf.registerChannelValue(User, 'listInPrivate',
     registry.Boolean(True, _("""Determines whether the output of 'user list'
     will be sent in private. This prevents mass-highlights of people who use
     their nick as their bot username.""")))

--- a/plugins/User/config.py
+++ b/plugins/User/config.py
@@ -43,8 +43,9 @@ def configure(advanced):
 
 
 User = conf.registerPlugin('User')
-# This is where your configuration variables (if any) should go.  For example:
-# conf.registerGlobalValue(User, 'someConfigVariableName',
-#     registry.Boolean(False, """Help for someConfigVariableName."""))
+conf.registerGlobalValue(User, 'listInPrivate',
+    registry.Boolean(True, _("""Determines whether the output of 'user list'
+    will be sent in private. This prevents mass-highlights of people who use
+    their nick as their bot username.""")))
 
 # vim:set shiftwidth=4 softtabstop=4 expandtab textwidth=79:

--- a/plugins/User/plugin.py
+++ b/plugins/User/plugin.py
@@ -88,7 +88,7 @@ class User(callbacks.Plugin):
                 users.append(u.name)
         if users:
             utils.sortBy(str.lower, users)
-            private = self.registryValue("listInPrivate")
+            private = self.registryValue("listInPrivate", msg.args[0])
             irc.reply(format('%L', users), private=private)
         else:
             if predicates:

--- a/plugins/User/plugin.py
+++ b/plugins/User/plugin.py
@@ -88,7 +88,8 @@ class User(callbacks.Plugin):
                 users.append(u.name)
         if users:
             utils.sortBy(str.lower, users)
-            irc.reply(format('%L', users))
+            private = self.registryValue("listInPrivate")
+            irc.reply(format('%L', users), private=private)
         else:
             if predicates:
                 irc.reply(_('There are no matching registered users.'))


### PR DESCRIPTION
Controlled by new config value plugins.User.listInPrivate.

This avoids mass-highlights of people who use their IRC nick as their bot username.