### PR TITLE
Filter: strip spaces in "unbinary" (Closes #1166)

### DIFF
--- a/plugins/Filter/plugin.py
+++ b/plugins/Filter/plugin.py
@@ -119,7 +119,7 @@ class Filter(callbacks.Plugin):
     hebrew = wrap(hebrew, ['text'])
 
     def _squish(self, text):
-        return ''.join(text.split())
+        return text.replace(' ', '')
 
     @internationalizeDocstring
     def squish(self, irc, msg, args, text):

--- a/plugins/Filter/plugin.py
+++ b/plugins/Filter/plugin.py
@@ -118,14 +118,16 @@ class Filter(callbacks.Plugin):
         irc.reply(self._hebrew_remover(text))
     hebrew = wrap(hebrew, ['text'])
 
+    def _squish(self, text):
+        return ''.join(text.split())
+
     @internationalizeDocstring
     def squish(self, irc, msg, args, text):
         """<text>
 
         Removes all the spaces from <text>.
         """
-        text = ''.join(text.split())
-        irc.reply(text)
+        irc.reply(self._squish(text))
     squish = wrap(squish, ['text'])
 
     @internationalizeDocstring
@@ -182,6 +184,7 @@ class Filter(callbacks.Plugin):
         Returns the character representation of binary <text>.
         Assumes ASCII, 8 digits per character.
         """
+        text = self._squish(text)  # Strip spaces.
         try:
             L = [chr(int(text[i:(i+8)], 2)) for i in range(0, len(text), 8)]
             irc.reply(''.join(L))

--- a/plugins/Filter/test.py
+++ b/plugins/Filter/test.py
@@ -86,13 +86,11 @@ class FilterTest(ChannelPluginTestCase):
 
     def testBinary(self):
         self.assertResponse('binary A', '01000001')
-    
-    def testUnbinary(self):
-        self.assertResponse('unbinary 011011010110111101101111', 'moo')
 
     def testUnbinary(self):
         self.assertResponse('unbinary 011011010110111101101111', 'moo')
         self.assertError('unbinary moo')
+        self.assertResponse('unbinary 01101101 01101111 01101111', 'moo')
 
     def testRot13(self):
         for s in map(str, range(1000, 1010)):


### PR DESCRIPTION
This makes `_squish()` a shared function to prevent code duplication. Also, remove duplicate a `testUnbinary` function, and add tests for this.