### PR TITLE
Google: Handle empty results in translate.

### DIFF
--- a/plugins/Google/plugin.py
+++ b/plugins/Google/plugin.py
@@ -267,7 +267,10 @@ class Google(callbacks.PluginRegexp):
         except:
             language = 'unknown'
 
-        return (''.join(x[0] for x in data[0]), language)
+        if data[0]:
+            return (''.join(x[0] for x in data[0]), language)
+        else:
+            return (_('No translations found.'), language)
 
     @internationalizeDocstring
     def translate(self, irc, msg, args, sourceLang, targetLang, text):


### PR DESCRIPTION
Fixes #1144

'ch' language code doesn't exist in Google Translate so naturally nothing comes back. Traditional chinese is 'zh-cn'. Using 'auto' also works.