### PR TITLE
Web & utils.web: Fix for HTMLParser in Python 3.5.0

### DIFF
--- a/plugins/Web/plugin.py
+++ b/plugins/Web/plugin.py
@@ -158,7 +158,7 @@ class Web(callbacks.PluginRegexp):
         parser.close()
         title = parser.title
         if title:
-            title = utils.web.htmlToText(parser.title.strip())
+            title = utils.web.htmlToText(title.strip())
         elif raiseErrors:
             if len(text) < size:
                 irc.reply(_('That URL appears to have no HTML title.'))

--- a/plugins/Web/plugin.py
+++ b/plugins/Web/plugin.py
@@ -155,6 +155,7 @@ class Web(callbacks.PluginRegexp):
             else:
                 return None
         parser.feed(text)
+        parser.close()
         title = parser.title
         if title:
             title = utils.web.htmlToText(parser.title.strip())

--- a/plugins/Web/test.py
+++ b/plugins/Web/test.py
@@ -67,7 +67,7 @@ class WebTestCase(ChannelPluginTestCase):
                         'title http://www.youtube.com/watch?v=x4BtiqPN4u8')
             self.assertResponse(
                     'title http://www.thefreedictionary.com/don%27t',
-                    "don't - definition of don't by The Free Dictionary")
+                    "Don't - definition of don't by The Free Dictionary")
 
         def testTitleSnarfer(self):
             try:

--- a/src/utils/web.py
+++ b/src/utils/web.py
@@ -254,6 +254,7 @@ def htmlToText(s, tagReplace=' '):
             pass
     x = HtmlToText(tagReplace)
     x.feed(s)
+    x.close()
     return x.getText()
 
 def mungeEmail(s):


### PR DESCRIPTION
[Relevant Python issue.](http://bugs.python.org/issue23144)

With Python 3.5.0, Web returns an empty string as the title. The 'proper' solution to this is to force processing  by calling HTMLParser.close().

The fixed test case was failing on my machine because the actual title is capitalized.