### PR TITLE
Fixing fd.geturl() failing call in titleSnarfer

### DIFF
--- a/plugins/Web/plugin.py
+++ b/plugins/Web/plugin.py
@@ -174,6 +174,7 @@ class Web(callbacks.PluginRegexp):
                 return
             title = self.getTitle(url)
             if title:
+                fd = utils.web.getUrlFd(url)
                 domain = utils.web.getDomain(fd.geturl()
                         if self.registryValue('snarferShowTargetDomain', channel)
                         else url)


### PR DESCRIPTION
I met an issue in titleSnarfer call in Web plugin.

Here is my patch.