### PR TITLE
Unix: ping 10 times instead of 5

### DIFF
--- a/plugins/Unix/plugin.py
+++ b/plugins/Unix/plugin.py
@@ -297,7 +297,7 @@ class Unix(callbacks.Plugin):
                     args.append(str(val))
                 if '-c' not in args:
                     args.append('-c')
-                    args.append('5')
+                    args.append('10')
                 args.append(host)
                 try:
                     with open(os.devnull) as null:


### PR DESCRIPTION
I believe 10 gives better picture on connectivity to the host than 5 and
is also more clear by 1 ping being 10%.