### PR TITLE
irclib: handle disconnections correctly for InspIRCd 2.0 networks

### DIFF
--- a/src/irclib.py
+++ b/src/irclib.py
@@ -1278,7 +1278,7 @@ class Irc(IrcCommandDispatcher, log.Firewalled):
         """Handles ERROR messages."""
         log.warning('Error message from %s: %s', self.network, msg.args[0])
         if not self.zombie:
-           if msg.args[0].startswith('Closing Link'):
+           if msg.args[0].lower().startswith('closing link'):
               self.driver.reconnect()
            elif 'too fast' in msg.args[0]: # Connecting too fast.
               self.driver.reconnect(wait=True)


### PR DESCRIPTION
The old code, which checked for "Closing Link" in the message, wouldn't have matched InspIRCd's way of closing connections (they send "Closing link" with a lowercase l):

```
DEBUG 2015-09-27T19:15:32 Incoming message (overdrive-irc): ERROR :Closing link: (LilyBot@0::1) [Quit: test]
```

If I remember correctly, this was causing some issues with autoreconnect not working on my network.