### PR TITLE
Web: normalize whitespace in titles

### DIFF
--- a/plugins/Web/plugin.py
+++ b/plugins/Web/plugin.py
@@ -145,7 +145,7 @@ class Web(callbacks.PluginRegexp):
                 return None
         parser.feed(text)
         parser.close()
-        title = ''.join(parser.data).strip()
+        title = utils.str.normalizeWhitespace(''.join(parser.data).strip())
         if title:
             return (target, title)
         elif raiseErrors:


### PR DESCRIPTION
This issue was bothering me for quite a while, as the title snarfer didn't cleanly strip newlines from titles. Not all sites are affected by this, but some, like the one below, are.

Sample link: http://googleblog.blogspot.com/2015/08/android-wear-now-works-with-iphones.html

Before: `<bot> 'Title: \nOfficial Google Blog: Android Wear now works with iPhones\n (at googleblog.blogspot.com)'`

After: `<bot> Title: Official Google Blog: Android Wear now works with iPhones (at googleblog.blogspot.com)`