### PR TITLE
Network: fix getopts key for --nossl

### DIFF
--- a/plugins/Network/plugin.py
+++ b/plugins/Network/plugin.py
@@ -102,7 +102,7 @@ class Network(callbacks.Plugin):
         conf.supybot.networks().add(network)
         assert newIrc.callbacks is irc.callbacks, 'callbacks list is different'
         irc.replySuccess(_('Connection to %s initiated.') % network)
-    connect = wrap(connect, ['owner', getopts({'ssl': ''}), 'something',
+    connect = wrap(connect, ['owner', getopts({'nossl': ''}), 'something',
                              additional('something'),
                              additional('something', '')])
 


### PR DESCRIPTION
c3dd5f8b64618de70414024c354b4867aaaa044c made plain text networks impossible to add. The getopts key needed to be changed from `ssl` to `nossl` in order to fix this.