### PR TITLE
ircutils: add $network to standard substitutions

### DIFF
--- a/src/ircutils.py
+++ b/src/ircutils.py
@@ -824,6 +824,7 @@ def standardSubstitute(irc, msg, text, env=None):
     if irc:
         vars.update({
             'botnick': irc.nick,
+            'network': irc.network,
             })
 
     if msg:

--- a/test/test_ircutils.py
+++ b/test/test_ircutils.py
@@ -219,6 +219,8 @@ class FunctionsTestCase(SupyTestCase):
         msg = ircmsgs.IrcMsg(':%s PRIVMSG #channel :stuff' % self.hostmask)
         class Irc(object):
             nick = 'bob'
+            network = 'testnet'
+
         irc = Irc()
 
         f = ircutils.standardSubstitute

--- a/test/test_standardSubstitute.py
+++ b/test/test_standardSubstitute.py
@@ -41,6 +41,7 @@ class FunctionsTestCase(SupyTestCase):
         class state:
             channels = {'#foo': holder()}
         nick = 'foobar'
+        network = 'testnet'
 
     @retry()
     def testStandardSubstitute(self):
@@ -81,6 +82,9 @@ class FunctionsTestCase(SupyTestCase):
         self.failIf(all(L[0].__eq__, L), 'all $randomnicks were the same')
         c = f(self.irc, msg, '$channel')
         self.assertEqual(c, msg.args[0])
+
+        net = f(self.irc, msg, '$network')
+        self.assertEqual(net, self.irc.network)
 
 
 


### PR DESCRIPTION
This is useful for setting the bot's quit message to things like "`Disconnect command received $nick@$network`", as the network field would then be automatically expanded.