### PR TITLE
Use HTTP proxy for HTTPS requests as well

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -1190,10 +1190,10 @@ class HttpProxy(registry.String):
                 'http': v,
                 'https': v
                 }
-    proxyHandler = ProxyHandler(proxies)
-    proxyOpenerDirector = build_opener(proxyHandler)
-    install_opener(proxyOpenerDirector)
-    super(HttpProxy, self).setValue(v)
+        proxyHandler = ProxyHandler(proxies)
+        proxyOpenerDirector = build_opener(proxyHandler)
+        install_opener(proxyOpenerDirector)
+        super(HttpProxy, self).setValue(v)
 
 registerGlobalValue(supybot.protocols.http, 'proxy',
     HttpProxy('', _("""Determines what proxy all HTTP requests should go

--- a/src/conf.py
+++ b/src/conf.py
@@ -35,6 +35,7 @@ import socket
 
 from . import ircutils, registry, utils
 from .utils import minisix
+from .utils.net import isSocketAddress
 from .version import version
 from .i18n import PluginInternationalization
 _ = PluginInternationalization()
@@ -1179,17 +1180,13 @@ class HttpProxy(registry.String):
     def setValue(self, v):
         proxies = {}
         if v != "":
-            # TODO: improve checks
-            if ':' not in v:
+            if isSocketAddress(v):
+                proxies = {
+                    'http': v,
+                    'https': v
+                    }
+            else:
                 self.error()
-            try:
-                int(v.rsplit(':', 1)[1])
-            except ValueError:
-                self.error()
-            proxies = {
-                'http': v,
-                'https': v
-                }
         proxyHandler = ProxyHandler(proxies)
         proxyOpenerDirector = build_opener(proxyHandler)
         install_opener(proxyOpenerDirector)

--- a/src/conf.py
+++ b/src/conf.py
@@ -38,6 +38,10 @@ from .utils import minisix
 from .version import version
 from .i18n import PluginInternationalization
 _ = PluginInternationalization()
+if minisix.PY2:
+    from urllib2 import build_opener, install_opener, ProxyHandler
+else:
+    from urllib.request import build_opener, install_opener, ProxyHandler
 
 ###
 # *** The following variables are affected by command-line options.  They are
@@ -1171,25 +1175,21 @@ registerGlobalValue(supybot.protocols.http, 'peekSize',
     found what it was looking for.""")))
 
 class HttpProxy(registry.String):
-  """Value must be a valid hostname:port string."""
-  def setValue(self, v):
-    if minisix.PY2:
-      from urllib2 import build_opener, install_opener, ProxyHandler
-    else:
-      from urllib.request import build_opener, install_opener, ProxyHandler
-    proxies = {}
-    if v != "":
-      # TODO: improve checks
-      if ':' not in v:
-        self.error()
-      try:
-        int(v.rsplit(':', 1)[1])
-      except ValueError:
-        self.error()
-      proxies = {
-        'http': v,
-        'https': v
-        }
+    """Value must be a valid hostname:port string."""
+    def setValue(self, v):
+        proxies = {}
+        if v != "":
+            # TODO: improve checks
+            if ':' not in v:
+                self.error()
+            try:
+                int(v.rsplit(':', 1)[1])
+            except ValueError:
+                self.error()
+            proxies = {
+                'http': v,
+                'https': v
+                }
     proxyHandler = ProxyHandler(proxies)
     proxyOpenerDirector = build_opener(proxyHandler)
     install_opener(proxyOpenerDirector)

--- a/src/utils/net.py
+++ b/src/utils/net.py
@@ -77,6 +77,17 @@ def getSocket(host, port=None, socks_proxy=None, vhost=None, vhostv6=None):
     else:
         raise socket.error('Something wonky happened.')
 
+def isSocketAddress(s):
+    if ':' in s:
+        host, port = s.rsplit(':', 1)
+        try:
+            int(port)
+            sock = getSocket(host, port)
+            return True
+        except (ValueError, socket.error):
+            pass
+    return False
+
 def isIP(s):
     """Returns whether or not a given string is an IP address.
 

--- a/src/utils/web.py
+++ b/src/utils/web.py
@@ -57,6 +57,7 @@ if minisix.PY2:
         return urllib.urlencode(*args, **kwargs).encode()
     from urllib2 import HTTPError, URLError
     from urllib import splithost, splituser
+    from urllib2 import build_opener, install_opener, ProxyHandler
 else:
     from http.client import InvalidURL
     from urllib.parse import urlsplit, urlunsplit, urlparse
@@ -72,6 +73,7 @@ else:
         return urllib.parse.urlencode(*args, **kwargs)
     from urllib.error import HTTPError, URLError
     from urllib.parse import splithost, splituser
+    from urllib.request import build_opener, install_opener, ProxyHandler
 
 class Error(Exception):
     pass
@@ -145,7 +147,12 @@ def getUrlFd(url, headers=None, data=None, timeout=None):
             request.add_data(data)
         httpProxy = force(proxy)
         if httpProxy:
-            request.set_proxy(httpProxy, 'http')
+            proxyHandler = ProxyHandler({
+                'http': httpProxy,
+                'https': httpProxy
+                })
+            proxyOpener = build_opener(proxyHandler)
+            install_opener(proxyOpener)
         fd = urlopen(request, timeout=timeout)
         return fd
     except socket.timeout as e:

--- a/src/utils/web.py
+++ b/src/utils/web.py
@@ -57,7 +57,6 @@ if minisix.PY2:
         return urllib.urlencode(*args, **kwargs).encode()
     from urllib2 import HTTPError, URLError
     from urllib import splithost, splituser
-    from urllib2 import build_opener, install_opener, ProxyHandler
 else:
     from http.client import InvalidURL
     from urllib.parse import urlsplit, urlunsplit, urlparse
@@ -73,7 +72,6 @@ else:
         return urllib.parse.urlencode(*args, **kwargs)
     from urllib.error import HTTPError, URLError
     from urllib.parse import splithost, splituser
-    from urllib.request import build_opener, install_opener, ProxyHandler
 
 class Error(Exception):
     pass
@@ -145,14 +143,6 @@ def getUrlFd(url, headers=None, data=None, timeout=None):
         else:
             request = url
             request.add_data(data)
-        httpProxy = force(proxy)
-        if httpProxy:
-            proxyHandler = ProxyHandler({
-                'http': httpProxy,
-                'https': httpProxy
-                })
-            proxyOpener = build_opener(proxyHandler)
-            install_opener(proxyOpener)
         fd = urlopen(request, timeout=timeout)
         return fd
     except socket.timeout as e:


### PR DESCRIPTION
Use proxy handler/opener classes, instead of request.set_proxy, to avoid any potential [bugs](http://bugs.python.org/issue1424152#msg68861) in older Python versions.

If configured, use the HTTP proxy for HTTPS requests as well.
_(Tested fine on both Python 2.7.6 and 3.4.3)_

This commit is a prerequisite for future commits related to #1234.