### PR TITLE
ShrinkUrl: Update API URL, now serving HTTPS links

### DIFF
--- a/plugins/ShrinkUrl/plugin.py
+++ b/plugins/ShrinkUrl/plugin.py
@@ -229,7 +229,7 @@ class ShrinkUrl(callbacks.PluginRegexp):
             irc.error(str(e))
     ur1 = thread(wrap(ur1, ['httpUrl']))
 
-    _x0Api = 'http://api.x0.no/?%s'
+    _x0Api = 'https://x0.no/api/?%s'
     @retry
     def _getX0Url(self, url):
         try:


### PR DESCRIPTION
http://api.x0.no/ now redirects to https://x0.no/api/. The latter supports and serves HTTPS redirect links!