### PR TITLE
always sort the produced config files

### DIFF
--- a/src/registry.py
+++ b/src/registry.py
@@ -192,7 +192,7 @@ def join(names):
 class Group(object):
     """A group; it doesn't hold a value unless handled by a subclass."""
     def __init__(self, help='', supplyDefault=False,
-                 orderAlphabetically=False, private=False):
+                 orderAlphabetically=True, private=False):
         self._help = utils.str.normalizeWhitespace(help)
         self._name = 'unset'
         self._added = []


### PR DESCRIPTION
I keep my stuff in a git repo, and I find pretty annoying to have to commit some imho nonsensical ordering change.

I'm not sure at all if this would break something else, I only quickly tested it and it seems to do what I'd expect.

I'm also unsure if it's preferred to have the main conf have a more meaningful order (more general/global options first, then the rest), but this would be a more bigger change (and not knowing supybot internals it would be impossible for me to do).