### PR TITLE
Web: optionally hide the domain in titleSnarfer

### DIFF
--- a/plugins/Web/config.py
+++ b/plugins/Web/config.py
@@ -52,6 +52,9 @@ conf.registerChannelValue(Web, 'titleSnarfer',
 conf.registerChannelValue(Web, 'snarferReportIOExceptions',
     registry.Boolean(False, _("""Determines whether the bot will notfiy the user
     about network exceptions like hostnotfound, timeout ....""")))
+conf.registerChannelValue(Web, 'snarferShowDomain',
+    registry.Boolean(True, _("""Determines whether domain names should be
+    displayed by the title snarfer.""")))
 conf.registerChannelValue(Web, 'snarferShowTargetDomain',
     registry.Boolean(False, _("""Determines whether the domain name displayed
     by the snarfer will be the original one (posted on IRC) or the target one

--- a/plugins/Web/plugin.py
+++ b/plugins/Web/plugin.py
@@ -179,7 +179,9 @@ class Web(callbacks.PluginRegexp):
                 domain = utils.web.getDomain(target
                         if self.registryValue('snarferShowTargetDomain', channel)
                         else url)
-                s = format(_('Title: %s (at %s)'), title, domain)
+                s = format(_('Title: %s'), title)
+                if self.registryValue('snarferShowDomain', channel):
+                    s += format(_(' (at %s)'), domain)
                 irc.reply(s, prefixNick=False)
     titleSnarfer = urlSnarfer(titleSnarfer)
     titleSnarfer.__doc__ = utils.web._httpUrlRe


### PR DESCRIPTION
This adds a snarferShowDomain option to optionally hide the domain ("(at site.abc)" text) in titleSnarfer output. Closes #1236.