### PR TITLE
conf: fix default and help for supybot.user

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -213,9 +213,8 @@ registerGlobalValue(supybot, 'ident',
     doesn't provide one by default.""")))
 
 registerGlobalValue(supybot, 'user',
-    registry.String('Limnoria $version', _("""Determines the real name which the bot sends to
-    the server. A standard real name using the current version of the bot
-    will be generated if this is left empty.""")))
+    registry.String('$version', _("""Determines the real name which the bot sends to
+    the server.""")))
 
 class Networks(registry.SpaceSeparatedSetOfStrings):
     List = ircutils.IrcSet


### PR DESCRIPTION
- "Limnoria $version" would expand to "Limnoria Limnoria 1234.56.78", which is probably not what's intended
- Empty real names no longer expand to anything since e5729bc86d8148dcb39339d488b674e125fe0aa9