### PR TITLE
Google: update link to supported languages list

### DIFF
--- a/plugins/Google/plugin.py
+++ b/plugins/Google/plugin.py
@@ -292,7 +292,7 @@ class Google(callbacks.PluginRegexp):
         Returns <text> translated from <source language> into <target
         language>. <source language> and <target language> take language
         codes (not language names), which are listed here:
-        https://cloud.google.com/translate/v2/translate-reference#supported_languages
+        https://cloud.google.com/translate/docs/languages
         """
         channel = msg.args[0]
         (text, language) = self._translate(sourceLang, targetLang, text)


### PR DESCRIPTION
Google has since reformatted their docs and moved the language support info to a separate page.