### PR TITLE
Use copyfile instead of copy

### DIFF
--- a/scripts/supybot
+++ b/scripts/supybot
@@ -208,7 +208,7 @@ if __name__ == '__main__':
             # The registry *MUST* be opened before importing log or conf.
             i18n.getLocaleFromRegistryFilename(registryFilename)
             registry.open_registry(registryFilename)
-            shutil.copy(registryFilename, registryFilename + '.bak')
+            shutil.copyfile(registryFilename, registryFilename + '.bak')
         except registry.InvalidRegistryFile as e:
             s = '%s in %s.  Please fix this error and start supybot again.' % \
                 (e, registryFilename)


### PR DESCRIPTION
The reason this would be useful is related to #896 . 

I have been trying to get Limnoria running on OpenShift v3 partly by using https://github.com/ProgVal/docker-limnoria (which I have some modifications for) and using https://github.com/minishift/minishift to run a local OpenShift cluster. 

According to https://docs.python.org/2/library/shutil.html copy attempts to set the ,permission bits while copyfile just copies the contents. This change should therefore have no side-affects in day to day use but makes Limnoria usable on OpenShift.

In OpenShift the user ID is random (and you are not running as root) therefore I was getting 
```[Errno 1] Operation not permitted: '/var/supybot/supybot.conf.bak```


