### PR TITLE
Allow specifying the format of Owner.announce

### DIFF
--- a/plugins/Owner/config.py
+++ b/plugins/Owner/config.py
@@ -45,6 +45,11 @@ Owner = conf.registerPlugin('Owner', True)
 conf.registerGlobalValue(Owner, 'public',
     registry.Boolean(True, """Determines whether this plugin is publicly
     visible."""))
+conf.registerGlobalValue(Owner, 'announceFormat',
+    registry.String('Announcement from my owner ($owner): $message',
+    """Determines the format of messages sent by the @announce command.
+    $owner may be used for the username of the owner calling this command,
+    and $message for the announcement being made."""))
 conf.registerGlobalValue(Owner, 'quitMsg',
     registry.String('$version', """Determines what quit message will be used by default.
     If the quit command is called without a quit message, this will be used.  If

--- a/plugins/Owner/plugin.py
+++ b/plugins/Owner/plugin.py
@@ -33,6 +33,7 @@ import os
 import sys
 import time
 import socket
+import string
 import linecache
 
 import re
@@ -282,11 +283,17 @@ class Owner(callbacks.Plugin):
         lobotomized in.
         """
         u = ircdb.users.getUser(msg.prefix)
-        text = 'Announcement from my owner (%s): %s' % (u.name, text)
+
+        template = self.registryValue('announceFormat')
+
+        text = ircutils.standardSubstitute(
+            irc, msg, template, env={'owner': u.name, 'message': text})
+
         for channel in irc.state.channels:
             c = ircdb.channels.getChannel(channel)
             if not c.lobotomized:
                 irc.queueMsg(ircmsgs.privmsg(channel, text))
+
         irc.noReply()
     announce = wrap(announce, ['text'])
 


### PR DESCRIPTION
Someone asked how to remove the owner's username from announcements, so it may be useful to make this configurable instead of making them edit a core plugin's code which is not the best idea, or write another plugin.