### PR TITLE
Math: Fix round() in calc command

### DIFF
--- a/plugins/Math/plugin.py
+++ b/plugins/Math/plugin.py
@@ -120,7 +120,7 @@ class Math(callbacks.Plugin):
     _mathEnv['abs'] = abs
     _mathEnv['max'] = max
     _mathEnv['min'] = min
-    _mathEnv['round'] = round
+    _mathEnv['round'] = lambda x, y: round(x, int(y))
     _mathSafeEnv = dict([(x,y) for x,y in _mathEnv.items()])
     _mathSafeEnv['factorial'] = _factorial
     _mathRe = re.compile(r'((?:(?<![A-Fa-f\d)])-)?'


### PR DESCRIPTION
The second argument of `round()` has to be an integer, and since every number is converted to a float to avoid using too much memory, a wrapper has to be added for this function. I've tested it with big numbers and it doesn't seem to cause any issue.