### PR TITLE
Make irc.state.history network specific

### DIFF
--- a/plugins/Owner/plugin.py
+++ b/plugins/Owner/plugin.py
@@ -160,9 +160,6 @@ class Owner(callbacks.Plugin):
                    'No servers are set for the %s network.' % network
         self.log.debug('Creating new Irc for %s.', network)
         newIrc = irclib.Irc(network)
-        for irc in world.ircs:
-            if irc != newIrc:
-                newIrc.state.history = irc.state.history
         driver = drivers.newDriver(newIrc)
         self._loadPlugins(newIrc)
         return newIrc


### PR DESCRIPTION
It is fairly counterintuitive for plugins to read the IrcState history, only to find that the message it got is from the wrong network.
I'm not sure why the original Supybot chose to link all the history buffers together, as those lines came from before Supybot was introduced to Git.

Closes #1211.

----

I realize that this is a breaking API change, which may subtly break any plugins relying on history to be global. I don't know of any specific plugins that would break however...