### PR TITLE
Fix exception raised due to lack of Content-Type on the Web plugin.

### DIFF
--- a/plugins/Web/plugin.py
+++ b/plugins/Web/plugin.py
@@ -279,6 +279,8 @@ class Web(callbacks.PluginRegexp):
         try:
             try:
                 size = fd.headers['Content-Length']
+                if size is None:
+                    raise KeyError('content-length')
                 irc.reply(format(_('%u is %S long.'), url, int(size)))
             except KeyError:
                 size = conf.supybot.protocols.http.peekSize()


### PR DESCRIPTION
The web size command raises a TypeError exception (line 282 in plugin.py) on URLs that do not contain a "Content-Length" header, due to Python3 returning a key for it with the value 'None'.

In Python2: 
```
>>> fd.headers["Content-Type"]
'text/html; charset=UTF-8'
>>> fd.headers["Content-Length"]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python2.7/rfc822.py", line 393, in __getitem__
    return self.dict[name.lower()]
KeyError: 'content-length'
```

In Python3:
```
>>> fd.headers['Content-Type']
'text/html; charset=UTF-8'
>>> fd.headers['Content-Length']
>>> 
```

This PR works around that by checking if the Content-Type header returned is 'None', and if so manually raises an exception that gets caught later on.
This way, backwards compatibility is maintained.