### PR TITLE
Socket: exempt local IPs from "not using TLS" warnings

### DIFF
--- a/src/drivers/Socket.py
+++ b/src/drivers/Socket.py
@@ -279,7 +279,10 @@ class SocketDriver(drivers.IrcDriver, drivers.ServersMixin):
             self.conn.connect((address, port))
             if network_config.ssl():
                 self.starttls()
-            elif not network_config.requireStarttls():
+            elif (not network_config.requireStarttls()) and \
+                    'localhost' not in address.lower() and \
+                    not address.startswith('127.') and \
+                    address not in ('0::1', '::1'):
                 drivers.log.warning(('Connection to network %s '
                     'does not use SSL/TLS, which makes it vulnerable to '
                     'man-in-the-middle attacks and passive eavesdropping. '


### PR DESCRIPTION
This is very minor, but I run a bot that connects to localhost where enabling TLS isn't very important. That said, I'm not sure if this is the most versatile check or whether this is a good place to put it (versus abstracting it away somewhere).