### PR TITLE
SSL Context setting

### DIFF
--- a/src/utils/web.py
+++ b/src/utils/web.py
@@ -58,11 +58,13 @@ if minisix.PY2:
     from urllib2 import HTTPError, URLError
     from urllib import splithost, splituser
 else:
+    import ssl
     from http.client import InvalidURL
     from urllib.parse import urlsplit, urlunsplit, urlparse
     from html.entities import entitydefs, name2codepoint
     from html.parser import HTMLParser
     import urllib.request, urllib.parse, urllib.error
+    context = ssl._create_unverified_context()
     Request = urllib.request.Request
     urlquote = urllib.parse.quote
     urlquote_plus = urllib.parse.quote_plus
@@ -143,7 +145,10 @@ def getUrlFd(url, headers=None, data=None, timeout=None):
         else:
             request = url
             request.add_data(data)
-        fd = urlopen(request, timeout=timeout)
+        try:
+            fd = urlopen(request, timeout=timeout)
+        except:
+            fd = urlopen(request, timeout=timeout, context=context)
         return fd
     except socket.timeout as e:
         raise Error(TIMED_OUT)

--- a/src/utils/web.py
+++ b/src/utils/web.py
@@ -149,6 +149,9 @@ def getUrlFd(url, headers=None, data=None, timeout=None, noverify=None):
         data = data.encode()
     if noverify is not None:
         nocert = True
+    # # Ideally we want to include something like this at some point:
+    # elif conf.supybot.protocols.ssl.verifyCertificates() is False:
+    #     nocert = True
     else:
         nocert = False
     try:
@@ -191,14 +194,14 @@ def getUrlFd(url, headers=None, data=None, timeout=None, noverify=None):
     except ValueError as e:
         raise Error(strError(e))
 
-def getUrlTargetAndContent(url, size=None, headers=None, data=None, timeout=None, noverify=None):
-    """getUrlTargetAndContent(url, size=None, headers=None, data=None, timeout=None, noverify=None)
+def getUrlTargetAndContent(url, size=None, headers=None, data=None, timeout=None):
+    """getUrlTargetAndContent(url, size=None, headers=None, data=None, timeout=None)
 
     Gets a page.  Returns two strings that are the page gotten and the
     target URL (ie. after redirections).  Size is an integer
     number of bytes to read from the URL.  Headers and data are dicts as per
     urllib.request.Request's arguments."""
-    fd = getUrlFd(url, headers=headers, data=data, timeout=timeout, nocert=nocert)
+    fd = getUrlFd(url, headers=headers, data=data, timeout=timeout)
     try:
         if size is None:
             text = fd.read()


### PR DESCRIPTION
Sets SSL context override when urlopen triggers the CERTIFICATE_VERIFY_FAILED error.

This type of error is raised in a number ways, but most consistently at the client end when either of the following is the case:

 1. The version of Python running the bot is unable to locate or access a relavent root certificates file to verify the sites TLS/SSL certificate.
 2. The site being checked is using a self-signed certificate.
 
 It should be noted that point no. 1 will be the case for everyone running Python 3.6 on an OS X system.  This is because as of Python 3.6.0, support was dropped for checking the original Apple OpenSSL installation files as they were too old to risk lulling users into a false sense of security by not raising the error.
 
 Nevertheless most bot plugins are better served by functional access to HTTPS URLs even with an override over a hard failure on every attempt to connect via TLS or SSL.
 
 TODO:
 
  1. Add a warning to be returned, either privately or in channel, whenever this override is triggered.
  
 Details on this override and how it works are [here](https://stackoverflow.com/a/28052583/2801707) and additional information on the OS X issue is [here](https://stackoverflow.com/a/42334357/2801707).