### PR TITLE
Use of the most usefull arguments for WHOX

### DIFF
--- a/plugins/NickAuth/plugin.py
+++ b/plugins/NickAuth/plugin.py
@@ -199,10 +199,11 @@ class NickAuth(callbacks.Plugin):
             self._auth(irc, msg.prefix, account)
 
     def do354(self, irc, msg):
-        if len(msg.args) != 6 or msg.args[1] != '1':
+        if len(msg.args) != 9 or msg.args[1] != '1':
             return
 
-        (__, ___, ident, host, nick, account) = msg.args
+        # irc.nick 1 user ip host nick status account gecos
+        (n, t, user, ip, host, nick, status, account, gecos) = msg.args
         prefix = '%s!%s@%s' % (nick, ident, host)
         user = ircdb.users.getUserFromNick(irc.network, account)
 

--- a/src/irclib.py
+++ b/src/irclib.py
@@ -515,10 +515,10 @@ class IrcState(IrcCommandDispatcher, log.Firewalled):
     def do354(self, irc, msg):
         # WHOX reply.
 
-        if len(msg.args) != 6 or msg.args[1] != '1':
+        if len(msg.args) != 9 or msg.args[1] != '1':
             return
-
-        (__, ___, user, host, nick, ___) = msg.args
+        # irc.nick 1 user ip host nick status account gecos
+        (n, t, user, ip, host, nick, status, account, gecos) = msg.args
         hostmask = '%s!%s@%s' % (nick, user, host)
         self.nicksToHostmasks[nick] = hostmask
 
@@ -1443,7 +1443,7 @@ class Irc(IrcCommandDispatcher, log.Firewalled):
     def doJoin(self, msg):
         if msg.nick == self.nick:
             channel = msg.args[0]
-            self.queueMsg(ircmsgs.who(channel, args=('%tuhna,1',))) # Ends with 315.
+            self.queueMsg(ircmsgs.who(channel, args=('%tuhnairf,1',))) # Ends with 315.
             self.queueMsg(ircmsgs.mode(channel)) # Ends with 329.
             for channel in msg.args[0].split(','):
                 self.queueMsg(ircmsgs.mode(channel, '+b'))


### PR DESCRIPTION
in order to avoid external plugins to do again the same request with more arguments, as thiis request must be made per channel and can take a lot of time, it's rather better if core limnoria already shares all needed informations