### PR TITLE
setup.py: Remove unneeded import of match for ceil() function

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ import warnings
 import datetime
 import tempfile
 import subprocess
-from math import ceil
 
 warnings.filterwarnings('always', category=DeprecationWarning)
 


### PR DESCRIPTION
The ceil() function was previously used in setup.py was removed by
commit c3a2c800f1c36adff0db9651c2d74c3f6a648f84. So we no longer need
it.