### PR TITLE
Fix time namespaces in setup.py when version file is unavailable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ except:
     if os.path.isfile(VERSION_FILE):
         from src.version import version
     else:
-        version = 'installed on ' + strftime("%Y-%m-%dT%H-%M-%S", gmtime())
+        version = 'installed on ' + time.strftime("%Y-%m-%dT%H-%M-%S", time.gmtime())
 try:
     os.unlink(VERSION_FILE)
 except OSError: # Does not exist


### PR DESCRIPTION
Running setup.py in environments where:

1) SOURCE_DATE_EPOCH is unavailable
2) git is not available
3) The version file is not present

Will die with:
```
Traceback (most recent call last):
  File "setup.py", line 69, in <module>
    version = 'installed on ' + strftime("%Y-%m-%dT%H-%M-%S", gmtime())
NameError: name 'strftime' is not defined
```