### PR TITLE
Explicitly convert ipaddress to unicode for ipaddress Python 2 backwards compatibility

### DIFF
--- a/src/drivers/Socket.py
+++ b/src/drivers/Socket.py
@@ -286,7 +286,7 @@ class SocketDriver(drivers.IrcDriver, drivers.ServersMixin):
                 self.starttls()
             # Suppress this warning for loopback IPs.
             elif (not network_config.requireStarttls()) and \
-                    (ipaddress is None or not ipaddress.ip_address(address).is_loopback):
+                    (ipaddress is None or not ipaddress.ip_address(unicode(address)).is_loopback):
                 drivers.log.warning(('Connection to network %s '
                     'does not use SSL/TLS, which makes it vulnerable to '
                     'man-in-the-middle attacks and passive eavesdropping. '


### PR DESCRIPTION
This fixes:

Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/supybot/drivers/Socket.py", line 289, in reconnect
    (ipaddress is None or not ipaddress.ip_address(address).is_loopback):
  File "/usr/lib/python2.7/site-packages/ipaddress.py", line 163, in ip_address
    ' a unicode object?' % address)
AddressValueError: 'x.x.x.x' does not appear to be an IPv4 or IPv6 address. Did you pass in a bytes (str in Python 2) instead of a unicode object?