### PR TITLE
src/conf.py: clarify supybot.protocols.http.proxy

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -1220,7 +1220,7 @@ class HttpProxy(registry.String):
         super(HttpProxy, self).setValue(v)
 
 registerGlobalValue(supybot.protocols.http, 'proxy',
-    HttpProxy('', _("""Determines what proxy all HTTP requests should go
+    HttpProxy('', _("""Determines what HTTP proxy all HTTP requests should go
     through.  The value should be of the form 'host:port'.""")))
 utils.web.proxy = supybot.protocols.http.proxy
 


### PR DESCRIPTION
As discussed on IRC, I found the help text unclear and thought it might mean any kind of proxy for HTTP requests while the other similar settings specify to be just for SOCKS proxies.