### PR TITLE
Add `channel` attribute to IrcMsg, and start using it in the core

### DIFF
--- a/plugins/Owner/plugin.py
+++ b/plugins/Owner/plugin.py
@@ -261,7 +261,7 @@ class Owner(callbacks.Plugin):
                 tokens = callbacks.tokenize(s, channel=msg.args[0])
                 self.Proxy(irc, msg, tokens)
             except SyntaxError as e:
-                irc.queueMsg(callbacks.error(msg, str(e)))
+                irc.error(str(e))
 
     def logmark(self, irc, msg, args, text):
         """<text>

--- a/src/irclib.py
+++ b/src/irclib.py
@@ -881,10 +881,19 @@ class Irc(IrcCommandDispatcher, log.Firewalled):
         msg.tag('receivedBy', self)
         msg.tag('receivedOn', self.network)
         msg.tag('receivedAt', time.time())
-        if msg.args and self.isChannel(msg.args[0]):
+
+        # Check if the message is addressed to a channel
+        if msg.args:
             channel = msg.args[0]
+            if not conf.supybot.protocols.irc.strictRfc():
+                statusmsg_chars = self.state.supported.get('statusmsg', '')
+                channel = channel.lstrip(statusmsg_chars)
+            if not self.isChannel(channel):
+                channel = None
         else:
             channel = None
+        msg.channel = channel
+
         preInFilter = str(msg).rstrip('\r\n')
         log.debug('Incoming message (%s): %s', self.network, preInFilter)
 

--- a/src/irclib.py
+++ b/src/irclib.py
@@ -882,10 +882,11 @@ class Irc(IrcCommandDispatcher, log.Firewalled):
         msg.tag('receivedOn', self.network)
         msg.tag('receivedAt', time.time())
 
-        # Check if the message is addressed to a channel
+        # Check if the message is sent to a channel
         if msg.args:
             channel = msg.args[0]
-            if not conf.supybot.protocols.irc.strictRfc():
+            if msg.command in ('NOTICE', 'PRIVMSG') and \
+                    not conf.supybot.protocols.irc.strictRfc():
                 statusmsg_chars = self.state.supported.get('statusmsg', '')
                 channel = channel.lstrip(statusmsg_chars)
             if not self.isChannel(channel):

--- a/src/ircmsgs.py
+++ b/src/ircmsgs.py
@@ -116,7 +116,7 @@ class IrcMsg(object):
     # On second thought, let's use methods for tagging.
     __slots__ = ('args', 'command', 'host', 'nick', 'prefix', 'user',
                  '_hash', '_str', '_repr', '_len', 'tags', 'reply_env',
-                 'server_tags', 'time')
+                 'server_tags', 'time', 'channel')
     def __init__(self, s='', command='', args=(), prefix='', msg=None,
             reply_env=None):
         assert not (msg and s), 'IrcMsg.__init__ cannot accept both s and msg'

--- a/src/ircutils.py
+++ b/src/ircutils.py
@@ -659,7 +659,10 @@ def safeArgument(s):
 
 def replyTo(msg):
     """Returns the appropriate target to send responses to msg."""
-    if isChannel(msg.args[0]):
+    if msg.channel:
+        # if message was sent to +#channel, we want to reply to +#channel;
+        # or unvoiced channel users will see the bot reply without the
+        # origin query
         return msg.args[0]
     else:
         return msg.nick
@@ -867,10 +870,7 @@ def standardSubstitute(irc, msg, text, env=None):
             vars.update(msg.reply_env)
 
     if irc and msg:
-        if isChannel(msg.args[0]):
-            channel = msg.args[0]
-        else:
-            channel = 'somewhere'
+        channel = msg.channel or 'somewhere'
         def randNick():
             if channel != 'somewhere':
                 L = list(irc.state.channels[channel].users)

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -47,6 +47,7 @@ class CommandsTestCase(SupyTestCase):
         realIrc = getTestIrc()
         realIrc.nick = 'test'
         realIrc.state.supported['chantypes'] = '#'
+        realIrc._tagMsg(msg)
         irc = callbacks.SimpleProxy(realIrc, msg)
         myspec = Spec(spec, **kwargs)
         state = myspec(irc, msg, given)

--- a/test/test_irclib.py
+++ b/test/test_irclib.py
@@ -470,6 +470,33 @@ class IrcTestCase(SupyTestCase):
         self.irc.feedMsg(msg2)
         self.assertEqual(list(self.irc.state.history), [msg1, msg2])
 
+    def testMsgChannel(self):
+        self.irc.reset()
+
+        self.irc.state.supported['statusmsg'] = '@'
+        self.irc.feedMsg(ircmsgs.IrcMsg('PRIVMSG #linux :foo bar baz!'))
+        self.assertEqual(self.irc.state.history[-1].channel, '#linux')
+        self.irc.feedMsg(ircmsgs.IrcMsg('PRIVMSG @#linux2 :foo bar baz!'))
+        self.assertEqual(self.irc.state.history[-1].channel, '#linux2')
+        self.irc.feedMsg(ircmsgs.IrcMsg('PRIVMSG +#linux3 :foo bar baz!'))
+        self.assertEqual(self.irc.state.history[-1].channel, None)
+
+        self.irc.state.supported['statusmsg'] = '+@'
+        self.irc.feedMsg(ircmsgs.IrcMsg('PRIVMSG #linux :foo bar baz!'))
+        self.assertEqual(self.irc.state.history[-1].channel, '#linux')
+        self.irc.feedMsg(ircmsgs.IrcMsg('PRIVMSG @#linux2 :foo bar baz!'))
+        self.assertEqual(self.irc.state.history[-1].channel, '#linux2')
+        self.irc.feedMsg(ircmsgs.IrcMsg('PRIVMSG +#linux3 :foo bar baz!'))
+        self.assertEqual(self.irc.state.history[-1].channel, '#linux3')
+
+        del self.irc.state.supported['statusmsg']
+        self.irc.feedMsg(ircmsgs.IrcMsg('PRIVMSG #linux :foo bar baz!'))
+        self.assertEqual(self.irc.state.history[-1].channel, '#linux')
+        self.irc.feedMsg(ircmsgs.IrcMsg('PRIVMSG @#linux2 :foo bar baz!'))
+        self.assertEqual(self.irc.state.history[-1].channel, None)
+        self.irc.feedMsg(ircmsgs.IrcMsg('PRIVMSG +#linux3 :foo bar baz!'))
+        self.assertEqual(self.irc.state.history[-1].channel, None)
+
     def testQuit(self):
         self.irc.reset()
         self.irc.feedMsg(ircmsgs.IrcMsg(':someuser JOIN #foo'))

--- a/test/test_irclib.py
+++ b/test/test_irclib.py
@@ -497,6 +497,15 @@ class IrcTestCase(SupyTestCase):
         self.irc.feedMsg(ircmsgs.IrcMsg('PRIVMSG +#linux3 :foo bar baz!'))
         self.assertEqual(self.irc.state.history[-1].channel, None)
 
+        # Test msg.channel is set only for PRIVMSG and NOTICE
+        self.irc.state.supported['statusmsg'] = '+@'
+        self.irc.feedMsg(ircmsgs.IrcMsg('NOTICE @#linux :foo bar baz!'))
+        self.assertEqual(self.irc.state.history[-1].channel, '#linux')
+        self.irc.feedMsg(ircmsgs.IrcMsg('NOTICE @#linux2 :foo bar baz!'))
+        self.assertEqual(self.irc.state.history[-1].channel, '#linux2')
+        self.irc.feedMsg(ircmsgs.IrcMsg('MODE @#linux3 +v foo'))
+        self.assertEqual(self.irc.state.history[-1].channel, None)
+
     def testQuit(self):
         self.irc.reset()
         self.irc.feedMsg(ircmsgs.IrcMsg(':someuser JOIN #foo'))

--- a/test/test_ircutils.py
+++ b/test/test_ircutils.py
@@ -281,12 +281,10 @@ class FunctionsTestCase(SupyTestCase):
     def testStandardSubstitute(self):
         # Stub out random msg and irc objects that provide what
         # standardSubstitute wants
-        msg = ircmsgs.IrcMsg(':%s PRIVMSG #channel :stuff' % self.hostmask)
-        class Irc(object):
-            nick = 'bob'
-            network = 'testnet'
+        irc = getTestIrc()
 
-        irc = Irc()
+        msg = ircmsgs.IrcMsg(':%s PRIVMSG #channel :stuff' % self.hostmask)
+        irc._tagMsg(msg)
 
         f = ircutils.standardSubstitute
         vars = {'foo': 'bar', 'b': 'c', 'i': 100,
@@ -344,9 +342,12 @@ class FunctionsTestCase(SupyTestCase):
         self.assertEqual('{}|^', ircutils.toLower('[]\\~'))
 
     def testReplyTo(self):
+        irc = getTestIrc()
         prefix = 'foo!bar@baz'
         channel = ircmsgs.privmsg('#foo', 'bar baz', prefix=prefix)
         private = ircmsgs.privmsg('jemfinch', 'bar baz', prefix=prefix)
+        irc._tagMsg(channel)
+        irc._tagMsg(private)
         self.assertEqual(ircutils.replyTo(channel), channel.args[0])
         self.assertEqual(ircutils.replyTo(private), private.nick)
 

--- a/test/test_standardSubstitute.py
+++ b/test/test_standardSubstitute.py
@@ -37,54 +37,53 @@ class holder:
     users = set(map(str, range(1000)))
 
 class FunctionsTestCase(SupyTestCase):
-    class irc:
-        class state:
-            channels = {'#foo': holder()}
-        nick = 'foobar'
-        network = 'testnet'
 
     @retry()
     def testStandardSubstitute(self):
+        irc = getTestIrc()
+        irc.state.channels = {'#foo': holder()}
+
         f = ircutils.standardSubstitute
         msg = ircmsgs.privmsg('#foo', 'filler', prefix='biff!quux@xyzzy')
-        s = f(self.irc, msg, '$rand')
+        irc._tagMsg(msg)
+        s = f(irc, msg, '$rand')
         try:
             int(s)
         except ValueError:
             self.fail('$rand wasn\'t an int.')
-        s = f(self.irc, msg, '$randomInt')
+        s = f(irc, msg, '$randomInt')
         try:
             int(s)
         except ValueError:
             self.fail('$randomint wasn\'t an int.')
-        self.assertEqual(f(self.irc, msg, '$botnick'), self.irc.nick)
-        self.assertEqual(f(self.irc, msg, '$who'), msg.nick)
-        self.assertEqual(f(self.irc, msg, '$WHO'),
+        self.assertEqual(f(irc, msg, '$botnick'), irc.nick)
+        self.assertEqual(f(irc, msg, '$who'), msg.nick)
+        self.assertEqual(f(irc, msg, '$WHO'),
                          msg.nick, 'stand. sub. not case-insensitive.')
-        self.assertEqual(f(self.irc, msg, '$nick'), msg.nick)
-        self.assertNotEqual(f(self.irc, msg, '$randomdate'), '$randomdate')
-        q = f(self.irc,msg,'$randomdate\t$randomdate')
+        self.assertEqual(f(irc, msg, '$nick'), msg.nick)
+        self.assertNotEqual(f(irc, msg, '$randomdate'), '$randomdate')
+        q = f(irc,msg,'$randomdate\t$randomdate')
         dl = q.split('\t')
         if dl[0] == dl[1]:
             self.fail ('Two $randomdates in the same string were the same')
-        q = f(self.irc, msg, '$randomint\t$randomint')
+        q = f(irc, msg, '$randomint\t$randomint')
         dl = q.split('\t')
         if dl[0] == dl[1]:
             self.fail ('Two $randomints in the same string were the same')
-        self.assertNotEqual(f(self.irc, msg, '$today'), '$today')
-        self.assertNotEqual(f(self.irc, msg, '$now'), '$now')
-        n = f(self.irc, msg, '$randnick')
-        self.failUnless(n in self.irc.state.channels['#foo'].users)
-        n = f(self.irc, msg, '$randomnick')
-        self.failUnless(n in self.irc.state.channels['#foo'].users)
-        n = f(self.irc, msg, '$randomnick '*100)
+        self.assertNotEqual(f(irc, msg, '$today'), '$today')
+        self.assertNotEqual(f(irc, msg, '$now'), '$now')
+        n = f(irc, msg, '$randnick')
+        self.failUnless(n in irc.state.channels['#foo'].users)
+        n = f(irc, msg, '$randomnick')
+        self.failUnless(n in irc.state.channels['#foo'].users)
+        n = f(irc, msg, '$randomnick '*100)
         L = n.split()
         self.failIf(all(L[0].__eq__, L), 'all $randomnicks were the same')
-        c = f(self.irc, msg, '$channel')
+        c = f(irc, msg, '$channel')
         self.assertEqual(c, msg.args[0])
 
-        net = f(self.irc, msg, '$network')
-        self.assertEqual(net, self.irc.network)
+        net = f(irc, msg, '$network')
+        self.assertEqual(net, irc.network)
 
 
 


### PR DESCRIPTION
Not yet in plugins, I'll update plugins at the same time as for network-specific config vars, as the main use of `msg.channel` would be for calling `self.registryValue()`


Opinions on this?