### PR TITLE
RSS: add 'announce chans' command to list channels a feed is announced to

### DIFF
--- a/plugins/RSS/plugin.py
+++ b/plugins/RSS/plugin.py
@@ -568,9 +568,9 @@ class RSS(callbacks.Plugin):
                         channels.append(ircnet.network + channel)
 
             if channels:
-                irc.reply(format("%s announces to %L.", feed, channels))
+                irc.reply(format("%s is announced to %L.", feed, channels))
             else:
-                irc.reply("%s does not announce to any channels." % feed)
+                irc.reply("%s is not announced to any channels." % feed)
 
         chans = wrap(chans, ['feedName'])
 

--- a/plugins/RSS/plugin.py
+++ b/plugins/RSS/plugin.py
@@ -550,6 +550,30 @@ class RSS(callbacks.Plugin):
         remove = wrap(remove, [('checkChannelCapability', 'op'),
                                many(first('url', 'feedName'))])
 
+        @internationalizeDocstring
+        def chans(self, irc, msg, args, feed):
+            """<name|url>
+
+            Returns a list of channels that the given feed name or URL is being
+            announced to.
+            """
+            plugin = irc.getCallback('RSS')
+            if not plugin.get_feed(feed):
+                irc.error(_("Unknown feed %s" % feed), Raise=True)
+
+            channels = []
+            for ircnet in world.ircs:
+                for channel in ircnet.state.channels:
+                    if feed in plugin.registryValue('announce', channel, ircnet.network):
+                        channels.append(ircnet.network + channel)
+
+            if channels:
+                irc.reply(format("%s announces to %L.", feed, channels))
+            else:
+                irc.reply("%s does not announce to any channels." % feed)
+
+        chans = wrap(chans, ['feedName'])
+
     @internationalizeDocstring
     def rss(self, irc, msg, args, url, n):
         """<name|url> [<number of headlines>]

--- a/plugins/RSS/test.py
+++ b/plugins/RSS/test.py
@@ -357,9 +357,15 @@ class RSSTestCase(ChannelPluginTestCase):
             timeFastForward(1.1)
             self.assertNotError('rss add advogato %s' % url)
             self.assertNotError('rss announce add advogato')
+            self.assertRegexp('rss announce chans advogato', 'advogato announces to.*%s%s' % (self.irc.network, self.channel))
+
             self.assertNotRegexp('rss announce', r'ValueError')
+
             self.assertNotError('rss announce remove advogato')
+            self.assertRegexp('rss announce chans advogato', 'advogato does not announce to any channels')
+
             self.assertNotError('rss remove advogato')
+            self.assertRegexp('rss announce chans advogato', 'Unknown feed')
 
         def testRss(self):
             timeFastForward(1.1)

--- a/plugins/RSS/test.py
+++ b/plugins/RSS/test.py
@@ -357,12 +357,12 @@ class RSSTestCase(ChannelPluginTestCase):
             timeFastForward(1.1)
             self.assertNotError('rss add advogato %s' % url)
             self.assertNotError('rss announce add advogato')
-            self.assertRegexp('rss announce chans advogato', 'advogato announces to.*%s%s' % (self.irc.network, self.channel))
+            self.assertRegexp('rss announce chans advogato', 'advogato is announced to.*%s%s' % (self.irc.network, self.channel))
 
             self.assertNotRegexp('rss announce', r'ValueError')
 
             self.assertNotError('rss announce remove advogato')
-            self.assertRegexp('rss announce chans advogato', 'advogato does not announce to any channels')
+            self.assertRegexp('rss announce chans advogato', 'advogato is not announced to any channels')
 
             self.assertNotError('rss remove advogato')
             self.assertRegexp('rss announce chans advogato', 'Unknown feed')


### PR DESCRIPTION
I'm assuming `get_feed()` is the right call here. This seems to work fine with both name and URL added feeds on my bot.

Closes #1322.