### PR TITLE
CatchTitleSnarferErrors

### DIFF
--- a/plugins/Web/plugin.py
+++ b/plugins/Web/plugin.py
@@ -154,45 +154,44 @@ class Web(callbacks.PluginRegexp):
                 timeout=timeout)
         except Exception as e:
             self.log.info('Web plugin TitleSnarfer: URL <%s> raised <%s>', url, str(e))
-            text = None
-        if text:
-            try:
-                text = text.decode(utils.web.getEncoding(text) or 'utf8',
-                        'replace')
-            except UnicodeDecodeError:
-                pass
-            if minisix.PY3 and isinstance(text, bytes):
-                if raiseErrors:
-                    irc.error(_('Could not guess the page\'s encoding. (Try '
-                            'installing python-charade.)'), Raise=True)
-                else:
-                    return None
-            try:
-                parser = Title()
-                parser.feed(text)
-            except UnicodeDecodeError:
-                # Workaround for Python 2
-                # https://github.com/ProgVal/Limnoria/issues/1359
-                parser = Title()
-                parser.feed(bytes(text)) # bytes() = str() in py2
-            parser.close()
-            title = utils.str.normalizeWhitespace(''.join(parser.data).strip())
-            if title:
-                return (target, title)
-            elif raiseErrors:
-                if len(text) < size:
-                    irc.error(_('That URL appears to have no HTML title.'),
-                            Raise=True)
-                else:
-                    irc.error(format(_('That URL appears to have no HTML title '
-                                     'within the first %S.'), size), Raise=True)
-            elif not raiseErrors:
-                if len(text) < size:
-                    self.log.info('Web plugin TitleSnarfer: URL <%s> appears'
-                                  ' to have no HTML title. ', url)
-                else:
-                    self.log.info('Web plugin TitleSnarfer: URL <%s> appears to have no HTML title'
-                                  ' within the first %S.', url, size)
+            return None
+        try:
+            text = text.decode(utils.web.getEncoding(text) or 'utf8',
+                    'replace')
+        except UnicodeDecodeError:
+            pass
+        if minisix.PY3 and isinstance(text, bytes):
+            if raiseErrors:
+                irc.error(_('Could not guess the page\'s encoding. (Try '
+                        'installing python-charade.)'), Raise=True)
+            else:
+                return None
+        try:
+            parser = Title()
+            parser.feed(text)
+        except UnicodeDecodeError:
+            # Workaround for Python 2
+            # https://github.com/ProgVal/Limnoria/issues/1359
+            parser = Title()
+            parser.feed(bytes(text)) # bytes() = str() in py2
+        parser.close()
+        title = utils.str.normalizeWhitespace(''.join(parser.data).strip())
+        if title:
+            return (target, title)
+        elif raiseErrors:
+            if len(text) < size:
+                irc.error(_('That URL appears to have no HTML title.'),
+                        Raise=True)
+            else:
+                irc.error(format(_('That URL appears to have no HTML title '
+                                 'within the first %S.'), size), Raise=True)
+        elif not raiseErrors:
+            if len(text) < size:
+                self.log.info('Web plugin TitleSnarfer: URL <%s> appears'
+                              ' to have no HTML title. ', url)
+            else:
+                self.log.info('Web plugin TitleSnarfer: URL <%s> appears to have no HTML title'
+                              ' within the first %S.', url, size)
 
     @fetch_sandbox
     def titleSnarfer(self, irc, msg, match):

--- a/plugins/Web/plugin.py
+++ b/plugins/Web/plugin.py
@@ -149,38 +149,50 @@ class Web(callbacks.PluginRegexp):
     def getTitle(self, irc, url, raiseErrors):
         size = conf.supybot.protocols.http.peekSize()
         timeout = self.registryValue('timeout')
-        (target, text) = utils.web.getUrlTargetAndContent(url, size=size,
+        try:
+            (target, text) = utils.web.getUrlTargetAndContent(url, size=size,
                 timeout=timeout)
-        try:
-            text = text.decode(utils.web.getEncoding(text) or 'utf8',
-                    'replace')
-        except UnicodeDecodeError:
-            pass
-        if minisix.PY3 and isinstance(text, bytes):
-            if raiseErrors:
-                irc.error(_('Could not guess the page\'s encoding. (Try '
-                        'installing python-charade.)'), Raise=True)
-            else:
-                return None
-        try:
-            parser = Title()
-            parser.feed(text)
-        except UnicodeDecodeError:
-            # Workaround for Python 2
-            # https://github.com/ProgVal/Limnoria/issues/1359
-            parser = Title()
-            parser.feed(text.encode('utf8'))
-        parser.close()
-        title = utils.str.normalizeWhitespace(''.join(parser.data).strip())
-        if title:
-            return (target, title)
-        elif raiseErrors:
-            if len(text) < size:
-                irc.error(_('That URL appears to have no HTML title.'),
-                        Raise=True)
-            else:
-                irc.error(format(_('That URL appears to have no HTML title '
-                                 'within the first %S.'), size), Raise=True)
+        except Exception as e:
+            self.log.info('Web plugin TitleSnarfer: URL <%s> raised <%s>', url, str(e))
+            text = None
+        if text:
+            try:
+                text = text.decode(utils.web.getEncoding(text) or 'utf8',
+                        'replace')
+            except UnicodeDecodeError:
+                pass
+            if minisix.PY3 and isinstance(text, bytes):
+                if raiseErrors:
+                    irc.error(_('Could not guess the page\'s encoding. (Try '
+                            'installing python-charade.)'), Raise=True)
+                else:
+                    return None
+            try:
+                parser = Title()
+                parser.feed(text)
+            except UnicodeDecodeError:
+                # Workaround for Python 2
+                # https://github.com/ProgVal/Limnoria/issues/1359
+                parser = Title()
+                parser.feed(bytes(text)) # bytes() = str() in py2
+            parser.close()
+            title = utils.str.normalizeWhitespace(''.join(parser.data).strip())
+            if title:
+                return (target, title)
+            elif raiseErrors:
+                if len(text) < size:
+                    irc.error(_('That URL appears to have no HTML title.'),
+                            Raise=True)
+                else:
+                    irc.error(format(_('That URL appears to have no HTML title '
+                                     'within the first %S.'), size), Raise=True)
+            elif not raiseErrors:
+                if len(text) < size:
+                    self.log.info('Web plugin TitleSnarfer: URL <%s> appears'
+                                  ' to have no HTML title. ', url)
+                else:
+                    self.log.info('Web plugin TitleSnarfer: URL <%s> appears to have no HTML title'
+                                  ' within the first %S.', url, size)
 
     @fetch_sandbox
     def titleSnarfer(self, irc, msg, match):

--- a/plugins/Web/plugin.py
+++ b/plugins/Web/plugin.py
@@ -156,10 +156,8 @@ class Web(callbacks.PluginRegexp):
             if raiseErrors:
                 irc.error(_('That URL raised <' + str(e)) + '>',
                           Raise=True)
-                return None
             else:
                 self.log.info('Web plugin TitleSnarfer: URL <%s> raised <%s>', url, str(e))
-                return None
         try:
             text = text.decode(utils.web.getEncoding(text) or 'utf8',
                     'replace')

--- a/plugins/Web/plugin.py
+++ b/plugins/Web/plugin.py
@@ -157,7 +157,7 @@ class Web(callbacks.PluginRegexp):
                 irc.error(_('That URL raised <' + str(e)) + '>',
                           Raise=True)
                 return None
-            elif not raiseErrors:
+            else:
                 self.log.info('Web plugin TitleSnarfer: URL <%s> raised <%s>', url, str(e))
                 return None
         try:
@@ -169,7 +169,7 @@ class Web(callbacks.PluginRegexp):
                     irc.error(_('Could not guess the page\'s encoding. (Try '
                                 'installing python-charade.)'), Raise=True)
                     return None
-                elif not raiseErrors:
+                else:
                     self.log.info('Web plugin TitleSnarfer: URL <%s> Could '
                                   'not guess the page\'s encoding. (Try '
                                   'installing python-charade.)', url)
@@ -193,7 +193,7 @@ class Web(callbacks.PluginRegexp):
             else:
                 irc.error(format(_('That URL appears to have no HTML title '
                                  'within the first %S.'), size), Raise=True)
-        elif not raiseErrors:
+        else:
             if len(text) < size:
                 self.log.info('Web plugin TitleSnarfer: URL <%s> appears'
                               ' to have no HTML title. ', url)

--- a/plugins/Web/plugin.py
+++ b/plugins/Web/plugin.py
@@ -168,12 +168,10 @@ class Web(callbacks.PluginRegexp):
                 if raiseErrors:
                     irc.error(_('Could not guess the page\'s encoding. (Try '
                                 'installing python-charade.)'), Raise=True)
-                    return None
                 else:
                     self.log.info('Web plugin TitleSnarfer: URL <%s> Could '
                                   'not guess the page\'s encoding. (Try '
                                   'installing python-charade.)', url)
-                    return None
         try:
             parser = Title()
             parser.feed(text)


### PR DESCRIPTION
Hi. Sorry about ditching the original pull request #1371 After doing it wrongly against 'master' and being moved to 'testing' I think that starting from an original branch seems to be the right thing. Plus after reviewing your comments there I concluded that this pull request is a better approach.
Not sure why git ended by replacing entire contiguous blocks because the changes against master aren't so big if you compare.
Description:
- Adds general error catching (404,403,ssl mismatches etc) to logs and validates 'text' for further processing.
      "  try:
            (target, text) = utils.web.getUrlTargetAndContent(url, size=size,
                timeout=timeout)
        except Exception as e:
            self.log.info('Web plugin TitleSnarfer: URL <%s> raised <%s>', url, str(e))
            text = None
        if text: "

- This is the best approach i could find with the higher success rate in case of previous encoding/decoding errors in the case of PY2
"                parser.feed(bytes(text)) # bytes() = str() in py2"

- Send information of these cases to log when no raiseErrors/title command
"           elif not raiseErrors:
                if len(text) < size:
                    self.log.info('Web plugin TitleSnarfer: URL <%s> appears'
                                  ' to have no HTML title. ', url)
                else:
                    self.log.info('Web plugin TitleSnarfer: URL <%s> appears to have no HTML title'
                                  ' within the first %S.', url, size)"
 
## Notes
- This pull request doesn't solve #1362. The issue is a dependence instead of a 'getTitle' code

Thanks!
