### PR TITLE
use string.capwords() - not .title()

### DIFF
--- a/plugins/Format/plugin.py
+++ b/plugins/Format/plugin.py
@@ -149,7 +149,7 @@ class Format(callbacks.Plugin):
 
         Returns <text> titlecased.
         """
-        irc.reply(text.title())
+        irc.reply(string.capwords(text, " "))
     title = wrap(title, ['text'])
 
     @internationalizeDocstring


### PR DESCRIPTION
closes #1366

There's a `string` helper function called `string.capwords` that does what `.title()` is expected, in my view, to do. It collapses duplicate spaces unless you specify a space as the second argument.

https://docs.python.org/3/library/string.html#string.capwords