### PR TITLE
regexp_wrapper: return None instead of False when search times out

### DIFF
--- a/src/commands.py
+++ b/src/commands.py
@@ -149,7 +149,7 @@ def process(f, *args, **kwargs):
 
 def regexp_wrapper(s, reobj, timeout, plugin_name, fcn_name):
     '''A convenient wrapper to stuff regexp search queries through a subprocess.
-    
+
     This is used because specially-crafted regexps can use exponential time
     and hang the bot.'''
     def re_bool(s, reobj):
@@ -163,7 +163,7 @@ def regexp_wrapper(s, reobj, timeout, plugin_name, fcn_name):
         v = process(re_bool, s, reobj, timeout=timeout, pn=plugin_name, cn=fcn_name)
         return v
     except ProcessTimeoutError:
-        return False
+        return None
 
 class UrlSnarfThread(world.SupyThread):
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
This allows plugins to detect whether a search timed out or did not match, which are two distinct outcomes.

Currently this affects SedRegex: if the search on one message times out, it assumes that the regex did not match and moves on to the next message. Often times, this ends up causing the wrong message to be replaced.