### PR TITLE
Refactor the Plugin command

### DIFF
--- a/plugins/Plugin/__init__.py
+++ b/plugins/Plugin/__init__.py
@@ -29,20 +29,14 @@
 
 """
 This plugin handles various plugin-related things, such as getting help for
-a plugin, getting a list of the loaded plugins, and searching and downloading
-plugins from supybot.com.
+a plugin or retrieving author info.
 """
 
 import supybot
 import supybot.world as world
 
-# Use this for the version of this plugin.  You may wish to put a CVS keyword
-# in here if you're keeping the plugin in CVS or some similar system.
 __version__ = "%%VERSION%%"
-
-# XXX Replace this with an appropriate author or supybot.Author instance.
 __author__ = supybot.authors.jemfinch
-
 # This is a dictionary mapping supybot.Author instances to lists of
 # contributions.
 __contributors__ = {
@@ -50,7 +44,6 @@ __contributors__ = {
     }
 
 from . import config
-# This had to be renamed because of stupid case-insensitivity issues.
 from . import plugin
 from imp import reload
 reload(plugin) # In case we're being reloaded.

--- a/plugins/Plugin/__init__.py
+++ b/plugins/Plugin/__init__.py
@@ -39,9 +39,12 @@ __version__ = "%%VERSION%%"
 __author__ = supybot.authors.jemfinch
 # This is a dictionary mapping supybot.Author instances to lists of
 # contributions.
+# Note: the tests for this plugin look at some of this data - update that too
+# as necessary
 __contributors__ = {
-    supybot.authors.skorobeus: ['contributors'],
-    }
+    supybot.authors.skorobeus: ['original contributors command'],
+    supybot.authors.jlu: ['refactored contributors command'],
+}
 
 from . import config
 from . import plugin

--- a/plugins/Plugin/plugin.py
+++ b/plugins/Plugin/plugin.py
@@ -201,24 +201,13 @@ class Plugin(callbacks.Plugin):
 
             authorInfo = contributorNicks[lnick]
             contributions = contributors[authorInfo]
-
-            (nonCommands, commands) = utils.iter.partition(lambda s: ' ' in s,
-                                                           contributions)
-            results = []
-            if commands:
-                s = _('command')
-                if len(commands) > 1:
-                    s = utils.str.pluralize(s)
-                results.append(format(_('the %L %s'), commands, s))
-            if nonCommands:
-                results.append(format(_('the %L'), nonCommands))
-
             fullName = getShortName(authorInfo)
-            if results:
-                return format(_('%s contributed %L to the %s plugin.'),
-                              fullName, results, cb.name())
+
+            if contributions:
+                return format(_('%s contributed the following to %s: %s'),
+                              fullName, cb.name(), ', '.join(contributions))
             else:
-                return _('%s has no specific listed contributions to the %s '
+                return _('%s did not list any specific contributions to the %s '
                          'plugin.') % (fullName, cb.name())
 
         # First we need to check and see if the requested plugin is loaded

--- a/plugins/Plugin/plugin.py
+++ b/plugins/Plugin/plugin.py
@@ -151,6 +151,7 @@ class Plugin(callbacks.Plugin):
             in the format 'First Last (nick)'.
             """
             return '%(name)s (%(nick)s)' % authorInfo.__dict__
+
         def buildContributorsString(longList):
             """
             Take a list of long names and turn it into :
@@ -158,48 +159,27 @@ class Plugin(callbacks.Plugin):
             """
             L = [getShortName(n) for n in longList]
             return format('%L', L)
-        def sortAuthors():
-            """
-            Sort the list of 'long names' based on the number of contributions
-            associated with each.
-            """
-            L = list(module.__contributors__.items())
-            def negativeSecondElement(x):
-                return -len(x[1])
-            utils.sortBy(negativeSecondElement, L)
-            return [t[0] for t in L]
+
         def buildPeopleString(module):
             """
             Build the list of author + contributors (if any) for the requested
             plugin.
             """
-            head = _('The %s plugin') % cb.name()
-            author = _('has not been claimed by an author')
-            conjunction = _('and')
-            contrib = _('has no contributors listed.')
-            hasAuthor = False
-            hasContribs = False
-            if hasattr(module, '__author__'):
-                if module.__author__ != supybot.authors.unknown:
-                    author = _('was written by %s') % str(module.__author__)
-                    hasAuthor = True
-            if hasattr(module, '__contributors__'):
-                contribs = sortAuthors()
-                if hasAuthor:
-                    try:
-                        contribs.remove(module.__author__)
-                    except ValueError:
-                        pass
-                if contribs:
-                    contrib = format(_('%s %h contributed to it.'),
-                                     buildContributorsString(contribs),
-                                     len(contribs))
-                    hasContribs = True
-                elif hasAuthor:
-                    contrib = _('has no additional contributors listed.')
-            if hasContribs and not hasAuthor:
-                conjunction = _('but')
-            return ' '.join([head, author, conjunction, contrib])
+            author = getattr(module, '__author__', supybot.authors.unknown)
+            if author != supybot.authors.unknown:
+                s = _('The %s plugin was written by %s. ' % (cb.name(), author))
+            else:
+                s = _('The %s plugin has not been claimed by an author. ')
+
+            contribs = getattr(module, '__contributors__', {})
+            if contribs:
+                s += format(_('%s %h contributed to it.'),
+                              buildContributorsString(contribs.keys()),
+                              len(contribs))
+            else:
+                s += _('No additional contributors are listed.')
+            return s
+
         def buildPersonString(module):
             """
             Build the list of contributions (if any) for the requested person

--- a/plugins/Plugin/test.py
+++ b/plugins/Plugin/test.py
@@ -34,7 +34,7 @@ class PluginTestCase(PluginTestCase):
     def testPlugin(self):
         self.assertRegexp('plugin ignore', 'available.*Utilities plugin')
         self.assertResponse('echo [plugin ignore]', 'Utilities')
-    
+
     def testPlugins(self):
         self.assertRegexp('plugins join', '(Format.*Admin|Admin.*Format)')
         self.assertRegexp('plugins plugin', 'Plugin')
@@ -50,25 +50,22 @@ class PluginTestCase(PluginTestCase):
     def testContributors(self):
         # Test ability to list contributors
         self.assertNotError('contributors Plugin')
+
         # Test ability to list contributions
-        # Verify that when a single command contribution has been made,
-        # the word "command" is properly not pluralized.
-        # Note: This will break if the listed person ever makes more than
-        # one contribution to the Plugin plugin
-        self.assertRegexp('contributors Plugin skorobeus', 'command')
-        # Test handling of pluralization of "command" when person has
-        # contributed more than one command to the plugin.
-        # -- Need to create this case, check it with the regexp 'commands'
+        # As of 2019-10-19 there is no more distinction between commands and non-commands
+        self.assertRegexp('contributors Plugin skorobeus', 'original contributors command')
+
+        # TODO: test handling of a person with multiple contributions to a command
+
         # Test handling of invalid plugin
         self.assertRegexp('contributors InvalidPlugin', 'not a valid plugin')
-        # Test handling of invalid person
+
+        # Test handling of unknown person. As of 2019-10-19 it doesn't matter whether
+        # they're listed in supybot.authors or not.
         self.assertRegexp('contributors Plugin noname',
-                          'not a registered contributor')
-        # Test handling of valid person with no contributions
-        # Note: This will break if the listed person ever makes a contribution
-        # to the Plugin plugin
+                          'not listed as a contributor')
         self.assertRegexp('contributors Plugin bwp',
-                          'listed as a contributor')
+                          'not listed as a contributor')
 
     def testContributorsIsCaseInsensitive(self):
         self.assertNotError('contributors Plugin Skorobeus')

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -64,6 +64,7 @@ class authors(object): # This is basically a bag.
     grantbow = Author('Grant Bowman', 'Grantbow', 'grantbow@grantbow.com')
     stepnem = Author('Štěpán Němec', 'stepnem', 'stepnem@gmail.com')
     progval = Author('Valentin Lorentz', 'ProgVal', 'progval@gmail.com')
+    jlu = Author('James Lu', 'GLolol', 'james@overdrivenetworks.com')
     unknown = Author('Unknown author', 'unknown', 'unknown@email.invalid')
 
     # Let's be somewhat safe about this.


### PR DESCRIPTION
In particular, I rewrote the contributors command to be simpler and removed a bunch of legacy code. Namely:

- `contributors` no longer sorts people by contribution count; it wasn't obvious that this was a feature to begin with
- `contributors [nick]` no longer distinguishes between commands and non-commands. This wasn't documented all that clearly and was prone to false positives (e.g. "internationalization" would be considered a command when it isn't)
- Removed legacy handling in `contributors [nick]` of people marked as both author and contributor. In practice, nobody actually does this.
