### PR TITLE
Web: Add supybot.plugins.Web.requestLanguage

### DIFF
--- a/plugins/Web/config.py
+++ b/plugins/Web/config.py
@@ -72,6 +72,10 @@ conf.registerChannelValue(Web, 'nonSnarfingRegexp',
 conf.registerChannelValue(Web, 'checkIgnored',
     registry.Boolean(True, _("""Determines whether the title snarfer checks
     if the author of a message is ignored.""")))
+conf.registerChannelValue(Web, 'requestLanguage',
+    registry.String('', _("""If set, the Accept-Language HTTP header will be set to this
+    value for title requests. Useful for overriding the auto-detected language based on
+    the server's location.""")))
 
 conf.registerGlobalValue(Web, 'urlWhitelist',
     registry.SpaceSeparatedListOfStrings([], """If set, bot will only fetch data


### PR DESCRIPTION
Some websites autodetect the language based on the server location.
This PR adds a variable that lets users override the served language by specifying the `Accept-Language` header.

```
<User> %web title https://twitter.com/
<Bot> Twitter. Ce qu'il se passe.
<User> %config supybot.plugins.Web.requestLanguage "en-GB"
<Bot> Ok
<User> %web title https://twitter.com/
<Bot> Twitter. It's what's happening
```