### PR TITLE
Aka: bind HTTP tests to a random port

### DIFF
--- a/src/test.py
+++ b/src/test.py
@@ -229,6 +229,8 @@ class PluginTestCase(SupyTestCase):
         conf.supybot.reply.whenAddressedBy.chars.setValue('@')
         conf.supybot.reply.error.detailed.setValue(True)
         conf.supybot.reply.whenNotCommand.setValue(True)
+        # Choose a random port for tests using the HTTP server
+        conf.supybot.servers.http.port.setValue(0)
         self.myVerbose = world.myVerbose
         def rmFiles(dir):
             for filename in os.listdir(dir):


### PR DESCRIPTION
Closes #1392.

(On a side note, I tried adding this setting to `src/httpserver.py` by calling `configGroup.port.setValue(0)`, but that change didn't seem to stick.)