### PR TITLE
Factoids: Filter duplicates in rank command

### DIFF
--- a/plugins/Factoids/plugin.py
+++ b/plugins/Factoids/plugin.py
@@ -565,7 +565,7 @@ class Factoids(callbacks.Plugin, plugins.ChannelDBHandler):
             number = self.registryValue('rankListLength', channel, irc.network)
         db = self.getDb(channel)
         cursor = db.cursor()
-        cursor.execute("""SELECT keys.key, relations.usage_count
+        cursor.execute("""SELECT DISTINCT keys.key, relations.usage_count
                           FROM keys, relations
                           WHERE relations.key_id=keys.id
                           ORDER BY relations.usage_count DESC


### PR DESCRIPTION
If there are multiple factoids with the same key, the rank command will return the key multiple times.
`#1 firstkey (234), #2 secondkey (111), #3 secondkey (111), #4 secondkey (111), ...`

This is corrected by using `SELECT DISTINCT` in the database query.