### PR TITLE
Add supybot.protocols.http.requestLanguage

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -1299,6 +1299,23 @@ registerGlobalValue(supybot.protocols.http, 'proxy',
     through.  The value should be of the form 'host:port'.""")))
 utils.web.proxy = supybot.protocols.http.proxy
 
+class HttpRequestLanguage(registry.String):
+    """Must be a valid HTTP Accept-Language value."""
+    __slots__ = ()
+    def setValue(self, v):
+        headers = utils.web.defaultHeaders
+        lkey = 'Accept-Language'
+        if v:
+            headers[lkey] = v
+        elif lkey in headers:
+            del headers[lkey]
+        super(HttpRequestLanguage, self).setValue(v)
+
+registerChannelValue(supybot.protocols.http, 'requestLanguage',
+    HttpRequestLanguage('', _("""If set, the Accept-Language HTTP header will be set to this
+    value for requests. Useful for overriding the auto-detected language based on
+    the server's location.""")))
+
 ###
 # supybot.protocols.ssl
 ###


### PR DESCRIPTION
Some websites autodetect the language based on the server location.
This PR adds a global variable that lets users override the served language by specifying the `Accept-Language` header.
The Web plugin has also been modified to implement channel-specific language settings.

```
<User> %web title https://twitter.com/
<Bot> Twitter. Ce qu'il se passe.
<User> %config supybot.protocols.http.requestLanguage "en-GB"
<Bot> Ok
<User> %web title https://twitter.com/
<Bot> Twitter. It's what's happening
```

Continuation of https://github.com/ProgVal/Limnoria/pull/1395