### PR TITLE
Keep closing parenthesis when snarfing URLs

### DIFF
--- a/src/utils/web.py
+++ b/src/utils/web.py
@@ -87,7 +87,7 @@ _domain = r'%s(?:\.%s)*\.[0-9a-z][-0-9a-z]+' % (_label, _label)
 _urlRe = r'(%s://(?:\S+@)?(?:%s|%s)(?::\d+)?(?:/[^\])>\s]*)?)' % (
         _scheme, _domain, _ipAddr)
 urlRe = re.compile(_urlRe, re.I)
-_httpUrlRe = r'(https?://(?:\S+@)?(?:%s|%s)(?::\d+)?(?:/[^\])>\s]*)?)' % \
+_httpUrlRe = r'(https?://(?:\S+@)?(?:%s|%s)(?::\d+)?(?:/[^\]>\s]*)?)' % \
              (_domain, _ipAddr)
 httpUrlRe = re.compile(_httpUrlRe, re.I)
 


### PR DESCRIPTION
Fixes [bug](https://github.com/ProgVal/Limnoria/issues/1416) when handling URLs with a closing parenthesis ')'. e.g. https://en.wikipedia.org/wiki/Harley_Quinn_(TV_series)