### PR TITLE
Implement text reminders

### DIFF
--- a/plugins/Scheduler/plugin.py
+++ b/plugins/Scheduler/plugin.py
@@ -90,12 +90,7 @@ class Scheduler(callbacks.Plugin):
                         # though we'll never know for sure, because other
                         # plugins can schedule stuff, too.
                         n = int(name)
-                    is_reminder = event.get('is_reminder', False)
-                    # Here we use event.get() method instead of event[]
-                    # This is to maintain compatibility with older bots
-                    # lacking 'is_reminder' in their event dicts
-                    self._add(network, event['msg'], event['time'], event['command'],
-                              is_reminder, n)
+                    self._add(network, event['msg'], event['time'], event['command'], n)
                 elif event['type'] == 'repeat': # repeating event
                     now = time.time()
                     first_run = event.get('first_run')
@@ -150,27 +145,13 @@ class Scheduler(callbacks.Plugin):
             self.Proxy(irc, msg, tokens)
         return f
 
-    def _makeReminderFunction(self, network, msg, text):
-        """Makes a function suitable for scheduling text"""
-        def f():
-            # If the network isn't available, pick any other one
-            irc = world.getIrc(network) or world.ircs[0]
-            replyIrc = callbacks.ReplyIrcProxy(irc, msg)
-            replyIrc.reply(_('Reminder: %s') % text, msg=msg, prefixNick=True)
-            del self.events[str(f.eventId)]
-        return f
-
-    def _add(self, network, msg, t, command, is_reminder=False, name=None):
-        if is_reminder:
-            f = self._makeReminderFunction(network, msg, command)
-        else:
-            f = self._makeCommandFunction(network, msg, command)
+    def _add(self, network, msg, t, command, name=None):
+        f = self._makeCommandFunction(network, msg, command)
         id = schedule.addEvent(f, t, name)
         f.eventId = id
         self.events[str(id)] = {'command':command,
-                                'is_reminder':is_reminder,
                                 'msg':msg,
-                                'network':network,
+                                'network': network,
                                 'time':t,
                                 'type':'single'}
         return id
@@ -189,19 +170,6 @@ class Scheduler(callbacks.Plugin):
         id = self._add(irc.network, msg, t, command)
         irc.replySuccess(format(_('Event #%i added.'), id))
     add = wrap(add, ['positiveInt', 'text'])
-
-    @internationalizeDocstring
-    def remind(self, irc, msg, args, seconds, text):
-        """ <seconds> <text>
-
-        Sets a reminder with string <text> to run <seconds> seconds in the
-        future. For example, 'scheduler remind [seconds 30m] "Hello World"'
-        will return '<nick> Reminder: Hello World' 30 minutes after being set.
-        """
-        t = time.time() + seconds
-        id = self._add(irc.network, msg, t, text, is_reminder=True)
-        irc.replySuccess(format(_('Reminder Event #%i added.'), id))
-    remind = wrap(remind, ['positiveInt', 'text'])
 
     @internationalizeDocstring
     def remove(self, irc, msg, args, id):
@@ -232,7 +200,7 @@ class Scheduler(callbacks.Plugin):
         assert id == name
         self.events[name] = {'command':command,
                              'msg':msg,
-                             'network':network,
+                             'network': network,
                              'time':seconds,
                              'type':'repeat',
                              'first_run': first_run,

--- a/plugins/Scheduler/test.py
+++ b/plugins/Scheduler/test.py
@@ -81,7 +81,6 @@ class SchedulerTestCase(ChannelPluginTestCase):
         timeFastForward(2)
         self.assertResponse(' ', 'Reminder: testRemind')
 
-
     def testRepeat(self):
         self.assertRegexp('scheduler repeat repeater 5 echo testRepeat',
             'testRepeat')

--- a/plugins/Scheduler/test.py
+++ b/plugins/Scheduler/test.py
@@ -76,10 +76,11 @@ class SchedulerTestCase(ChannelPluginTestCase):
 
     def testRemind(self):
         self.assertNotError('scheduler remind 5 testRemind')
-        timeFastForward(5)
-        self.assertResponse(' ', 'Reminder: testRemind')
         timeFastForward(3)
         self.assertNoResponse(' ', timeout=1)
+        timeFastForward(2)
+        self.assertResponse(' ', 'Reminder: testRemind')
+
 
     def testRepeat(self):
         self.assertRegexp('scheduler repeat repeater 5 echo testRepeat',

--- a/plugins/Scheduler/test.py
+++ b/plugins/Scheduler/test.py
@@ -74,6 +74,13 @@ class SchedulerTestCase(ChannelPluginTestCase):
         timeFastForward(5)
         self.assertNoResponse(' ', timeout=1)
 
+    def testRemind(self):
+        self.assertNotError('scheduler remind 5 testRemind')
+        timeFastForward(5)
+        self.assertResponse(' ', 'Reminder: testRemind')
+        timeFastForward(3)
+        self.assertNoResponse(' ', timeout=1)
+
     def testRepeat(self):
         self.assertRegexp('scheduler repeat repeater 5 echo testRepeat',
             'testRepeat')


### PR DESCRIPTION
Implemented text based reminders. Appropriately changed _restoreEvents()

TODO: `@scheduler list` should not display reminders as they may contain sensitive data.

[flake8 (http link) ](http://ix.io/2zzU) 

L84 may be redundant

![tests](https://user-images.githubusercontent.com/59024702/94989272-078cd900-0591-11eb-80f2-347a44e1656f.png)

