### PR TITLE
resolve warnings about 'is not' and integer comparisons

### DIFF
--- a/scripts/supybot-adduser
+++ b/scripts/supybot-adduser
@@ -56,7 +56,7 @@ def main():
                       help='capability the user should have; '
                            'this option may be given multiple times.')
     (options, args) = parser.parse_args()
-    if len(args) is not 1:
+    if len(args) != 1:
         parser.error('Specify the users.conf file you\'d like to use.  '
                      'Be sure *not* to specify your registry file, generated '
                      'by supybot-wizard.  This is not the file you want.  '

--- a/scripts/supybot-reset-password
+++ b/scripts/supybot-reset-password
@@ -52,7 +52,7 @@ def main():
                       dest='password',
                       help='password for the user.')
     (options, args) = parser.parse_args()
-    if len(args) is not 1:
+    if len(args) != 1:
         parser.error('Specify the users.conf file you\'d like to use.  '
                      'Be sure *not* to specify your registry file, generated '
                      'by supybot-wizard.  This is not the file you want.  '


### PR DESCRIPTION
running supybot-adduser (or supybot-reset-password) with a recent
python would result in the warning:

> ```
> /usr/local/bin/supybot-adduser:59: SyntaxWarning: "is not" with a literal. Did you mean "!="?
> if len(args) is not 1:
> ```

This commits corrects the syntax.
`