### PR TITLE
Fix HTML entities not escaped in RSS feed title

### DIFF
--- a/plugins/RSS/plugin.py
+++ b/plugins/RSS/plugin.py
@@ -39,6 +39,7 @@ import string
 import socket
 import threading
 import feedparser
+import html
 
 import supybot.conf as conf
 import supybot.utils as utils
@@ -430,6 +431,7 @@ class RSS(callbacks.Plugin):
                     self.registryValue(key_name, channel, network)
         else:
             template = self.registryValue(key_name, channel, network)
+        entry['title'] = html.unescape(entry['title'])
         date = entry.get('published_parsed')
         date = utils.str.timestamp(date)
         s = string.Template(template).substitute(


### PR DESCRIPTION
RSS announce does not currently unescape HTML entities.

I scratched my head on where exactly to unescape them, and doing that when announcing seems the more reasonable place to do it.
I also looked if feedparser could already do that, but to no avail.

Before:
> testfeed: Generic support • Re: Channels do not remain &amp;quot;persistent&amp;quot;

After:
> testfeed: Generic support • Re: Channels do not remain "persistent"