### PR TITLE
PluginDownloader: Change default branch from master to HEAD

### DIFF
--- a/plugins/PluginDownloader/plugin.py
+++ b/plugins/PluginDownloader/plugin.py
@@ -57,7 +57,7 @@ class GitRepository(VersionnedRepository):
     pass
 
 class GithubRepository(GitRepository):
-    def __init__(self, username, reponame, path='/', branch='master'):
+    def __init__(self, username, reponame, path='/', branch='HEAD'):
         self._username = username
         self._reponame = reponame
         self._branch = branch


### PR DESCRIPTION
Many people are renaming their default branches from master to main or something else (I just renamed mine). Using HEAD works no matter what the default branch is named.