### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 setuptools
+testresources
 chardet
 pytz
 python-dateutil


### PR DESCRIPTION
When installing Limnoria globally following the tutorial found at https://docs.limnoria.net/use/install.html#global-installation-with-root-access, I got the following error:
- ERROR: launchpadlib 1.10.13 requires testresources, which is not installed.
Installing testresources manually seems to solve the issue, so it's probably a good idea to add it to the default libs?