### PR TITLE
increase the timeout for Fediverse's tests

### DIFF
--- a/plugins/Fediverse/test.py
+++ b/plugins/Fediverse/test.py
@@ -100,7 +100,7 @@ class NetworkedFediverseTestCase(BaseFediverseTestCase):
 
 
 class NetworklessFediverseTestCase(BaseFediverseTestCase):
-    timeout = 0.1
+    timeout = 0.5
 
     @contextlib.contextmanager
     def mockWebfingerSupport(self, value):


### PR DESCRIPTION
At least in Debian CI they routinely timeout when they run in the
busiest server.

I haven't actually tested the new timeout, but since it's literally 5 times more (whilst still being half a second) I'm optimistic it ought to be enough!