### PR TITLE
Bugfix typos [skip ci]

### DIFF
--- a/src/callbacks.py
+++ b/src/callbacks.py
@@ -724,7 +724,7 @@ class ReplyIrcProxy(RichReplyMethods):
     def _replyOverhead(self, target, targetNick, prefixNick):
         """Returns the number of bytes added to a PRIVMSG payload, either by
         Limnoria itself or by the server.
-        Ignores tag bytes, as they are accounted for separatly."""
+        Ignores tag bytes, as they are accounted for separately."""
         overhead = (
             len(':')
             + len(self.irc.prefix.encode())
@@ -1139,7 +1139,7 @@ class NestedCommandsIrcProxy(ReplyIrcProxy):
         # evaluated our own list of arguments.
         assert not self.finalEvaled, 'finalEval called twice.'
         self.finalEvaled = True
-        # Now, the way we call a command is we iterate over the loaded pluings,
+        # Now, the way we call a command is we iterate over the loaded plugins,
         # asking each one if the list of args we have interests it.  The
         # way we do that is by calling getCommand on the plugin.
         # The plugin will return a list of args which it considers to be

--- a/src/drivers/__init__.py
+++ b/src/drivers/__init__.py
@@ -61,7 +61,7 @@ class IrcDriver(object):
         raise NotImplementedError
 
     def die(self):
-        # The end of any overrided die method should be
+        # The end of any overridden die method should be
         # "super(Class, self).die()", in order to make
         # sure this (and anything else later added) is done.
         remove(self.name())

--- a/src/registry.py
+++ b/src/registry.py
@@ -445,7 +445,7 @@ class Value(Group):
             # The complicated case. We want a net+chan specific value,
             # which may come in three different ways:
             #
-            # 1. it was set explicitely net+chan
+            # 1. it was set explicitly net+chan
             # 2. it's inherited from a net specific value (which may itself be
             #    inherited from the base value)
             # 3. it's inherited from the chan specific value (which is not a
@@ -453,7 +453,7 @@ class Value(Group):
             #    load configuration from old bots).
             #
             # The choice between 2 and 3 is done by checking which of the
-            # net-specific and chan-specific values was set explicitely by
+            # net-specific and chan-specific values was set explicitly by
             # a user/admin. In case both were, the net-specific value is used
             # (there is no particular reason for this, I just think it makes
             # more sense).


### PR DESCRIPTION
There are small typos in:
- src/callbacks.py
- src/drivers/__init__.py
- src/registry.py

Fixes:
- Should read `plugins` rather than `pluings`.
- Should read `overridden` rather than `overrided`.
- Should read `explicitly` rather than `explicitely`.

Closes #1475