### PR TITLE
getUrlFd: chain the original exception so that plugins can handle them further

### DIFF
--- a/src/utils/web.py
+++ b/src/utils/web.py
@@ -153,18 +153,18 @@ def getUrlFd(url, headers=None, data=None, timeout=None):
         fd = urlopen(request, timeout=timeout)
         return fd
     except socket.timeout as e:
-        raise Error(TIMED_OUT)
+        raise Error(TIMED_OUT) from e
     except sockerrors as e:
-        raise Error(strError(e))
+        raise Error(strError(e)) from e
     except InvalidURL as e:
-        raise Error('Invalid URL: %s' % e)
+        raise Error('Invalid URL: %s' % e) from e
     except HTTPError as e:
-        raise Error(strError(e))
+        raise Error(strError(e)) from e
     except URLError as e:
-        raise Error(strError(e.reason))
+        raise Error(strError(e.reason)) from e
     # Raised when urllib doesn't recognize the url type
     except ValueError as e:
-        raise Error(strError(e))
+        raise Error(strError(e)) from e
 
 def getUrlTargetAndContent(url, size=None, headers=None, data=None, timeout=None):
     """getUrlTargetAndContent(url, size=None, headers=None, data=None, timeout=None)


### PR DESCRIPTION
Note: This uses a Python 3 specific syntax, which means that the minisix usage in utils.web probably isn't useful anymore.

A lot of APIs, including LastFM and GitHub, serve detailed API errors in the body text even if the request returned an error.
This allows plugins to track HTTP errors returned from urllib and present these detailed messages (although the syntax to do so isn't the prettiest).

An example with my LastFM plugin:

```diff
diff --git a/LastFM/plugin.py b/LastFM/plugin.py
index de9087d..9bf1366 100644
--- a/LastFM/plugin.py
+++ b/LastFM/plugin.py
@@ -42,6 +42,7 @@ import supybot.log as log
 import supybot.ircdb as ircdb
 
 import json
+import urllib.error
 from datetime import datetime
 from .local import accountsdb
 
@@ -80,15 +81,20 @@ class LastFM(callbacks.Plugin):
 
         # see https://www.last.fm/api/show/user.getRecentTracks
         url = "%sapi_key=%s&method=user.getrecenttracks&user=%s&format=json" % (self.APIURL, apiKey, user)
+        self.log.debug("LastFM.np: url %s", url)
         try:
             f = utils.web.getUrl(url).decode("utf-8")
         except utils.web.Error as e:
-            irc.error(str(e), Raise=True)
-        self.log.debug("LastFM.np: url %s", url)
+            if isinstance(e.__cause__, urllib.error.HTTPError):
+                # When receiving an HTTP error, try reading and showing the API response anyways
+                # This requires a Limnoria version > 2021-08-01
+                f = e.__cause__.read().decode("utf-8")
+            else:
+               irc.error(str(e), Raise=True)

         data = json.loads(f)
         if "error" in data:
-            irc.error("%s: %s" % (data["error"], data.get("message")), Raise=True)
+            irc.error("LastFM API Error %s: %s" % (data["error"], data.get("message")), Raise=True)
         elif "recenttracks" not in data:
             irc.error("No recenttracks data found for %s" % user, Raise=True)
```

Before, the plugin would show generic errors like `Error: HTTP Error 400: Bad Request`. With this patch it can show the source error, like `Error: LastFM API Error 10: Invalid API key - You must be granted a valid key by last.fm`