### PR TITLE
utils: Rewrite i18n initialization

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -33,10 +33,7 @@ from . import dynamicScope
 
 from . import i18n
 
-builtins = (__builtins__ if isinstance(__builtins__, dict) else __builtins__.__dict__)
-builtins['supybotInternationalization'] = i18n.PluginInternationalization()
 from . import utils
-del builtins['supybotInternationalization']
 
 (__builtins__ if isinstance(__builtins__, dict) else __builtins__.__dict__)['format'] = utils.str.format
 

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -50,6 +50,7 @@ csv.split = split
 
 builtins = (__builtins__ if isinstance(__builtins__, dict) else __builtins__.__dict__)
 
+
 # We use this often enough that we're going to stick it in builtins.
 def force(x):
     if callable(x):
@@ -57,8 +58,6 @@ def force(x):
     else:
         return x
 builtins['force'] = force
-
-internationalization = builtins.get('supybotInternationalization', None)
 
 # These imports need to happen below the block above, so things get put into
 # __builtins__ appropriately.

--- a/src/utils/gen.py
+++ b/src/utils/gen.py
@@ -45,7 +45,9 @@ from . import crypt
 from .str import format
 from .file import mktemp
 from . import minisix
-from . import internationalization as _
+
+# will be replaced by supybot.i18n.install()
+_ = lambda x: x
 
 def warn_non_constant_time(f):
     @functools.wraps(f)


### PR DESCRIPTION
The previous implementation was messy and needlessly complicated

This simplifies the logic and removes hackiness by making utils/str.py
handle internationalization logic itself, instead of bending over
backwards to load logic from the parent package at import time.