### PR TITLE
Add ability to exclude channel from self censoring

### DIFF
--- a/plugins/BadWords/config.py
+++ b/plugins/BadWords/config.py
@@ -114,8 +114,8 @@ conf.registerGlobalValue(BadWords, 'stripFormatting',
     plugins that do coloring or bolding of text.""")))
 
 conf.registerChannelValue(BadWords, 'selfCensor',
-    registry.Boolean(True, _("""Determines whether the bot will filter itself in
-    this channel.""")))
+    registry.Boolean(True, _("""Determines whether the bot will filter its own
+    messages.""")))
 conf.registerChannelValue(BadWords, 'kick',
     registry.Boolean(False, _("""Determines whether the bot will kick people with
     a warning when they use bad words.""")))

--- a/plugins/BadWords/config.py
+++ b/plugins/BadWords/config.py
@@ -113,6 +113,9 @@ conf.registerGlobalValue(BadWords, 'stripFormatting',
     filtering.  If it's True, however, it will interact poorly with other
     plugins that do coloring or bolding of text.""")))
 
+conf.registerChannelValue(BadWords, 'selfCensor',
+    registry.Boolean(True, _("""Determines whether the bot will filter itself in
+    this channel.""")))
 conf.registerChannelValue(BadWords, 'kick',
     registry.Boolean(False, _("""Determines whether the bot will kick people with
     a warning when they use bad words.""")))

--- a/plugins/BadWords/messages.pot
+++ b/plugins/BadWords/messages.pot
@@ -81,18 +81,24 @@ msgstr ""
 
 #: config.py:117
 msgid ""
+"Determines whether the bot will filter itself in\n"
+"    this channel."
+msgstr ""
+
+#: config.py:120
+msgid ""
 "Determines whether the bot will kick people with\n"
 "    a warning when they use bad words."
 msgstr ""
 
-#: config.py:120
+#: config.py:123
 msgid ""
 "You have been kicked for using a word\n"
 "    prohibited in the presence of this bot.  Please use more appropriate\n"
 "    language in the future."
 msgstr ""
 
-#: config.py:122
+#: config.py:125
 msgid ""
 "Determines the kick message used by the\n"
 "    bot when kicking users for saying bad words."

--- a/plugins/BadWords/messages.pot
+++ b/plugins/BadWords/messages.pot
@@ -81,8 +81,8 @@ msgstr ""
 
 #: config.py:117
 msgid ""
-"Determines whether the bot will filter itself in\n"
-"    this channel."
+"Determines whether the bot will filter its own\n"
+"    messages."
 msgstr ""
 
 #: config.py:120

--- a/plugins/BadWords/plugin.py
+++ b/plugins/BadWords/plugin.py
@@ -104,9 +104,10 @@ class BadWords(callbacks.Privmsg):
             self.lastModified = time.time()
 
     def outFilter(self, irc, msg):
+        channel = msg.channel
         if self.filtering and msg.command == 'PRIVMSG' \
-                and (self.words() or self.phrases()):
-            channel = msg.channel
+                and (self.words() or self.phrases()) \
+                and self.registryValue('selfCensor', channel, irc.network):
             self.updateRegexp(channel, irc.network)
             s = msg.args[1]
             if self.registryValue('stripFormatting'):


### PR DESCRIPTION
Adds a `selfCensor` per channel setting to allow excepting a channel from the bot's censoring of its own messages.