### PR TITLE
PluginDownloader cleanup: drop automatic 2to3 and legacy repos

### DIFF
--- a/plugins/PluginDownloader/plugin.py
+++ b/plugins/PluginDownloader/plugin.py
@@ -201,64 +201,10 @@ repositories = utils.InsensitivePreservingDict({
                                                    'progval',
                                                    'Supybot-plugins'
                                                    ),
-               'quantumlemur':     GithubRepository(
-                                                   'quantumlemur',
-                                                   'Supybot-plugins',
-                                                   ),
-               'stepnem':          GithubRepository(
-                                                   'stepnem',
-                                                   'supybot-plugins',
-                                                   ),
-               'code4lib-snapshot':GithubRepository(
-                                                   'code4lib',
-                                                   'supybot-plugins',
-                                                   'Supybot-plugins-20060723',
-                                                   ),
-               'code4lib-edsu':    GithubRepository(
-                                                   'code4lib',
-                                                   'supybot-plugins',
-                                                   'edsu-plugins',
-                                                   ),
-               'code4lib':         GithubRepository(
-                                                   'code4lib',
-                                                   'supybot-plugins',
-                                                   'plugins',
-                                                   ),
-               'nanotube-bitcoin': GithubRepository(
-                                                   'nanotube',
-                                                   'supybot-bitcoin-'
-                                                             'marketmonitor',
-                                                   ),
-               'mtughan-weather':  GithubRepository(
-                                                   'mtughan',
-                                                   'Supybot-Weather',
-                                                   ),
                'SpiderDave':       GithubRepository(
                                                    'SpiderDave',
                                                    'spidey-supybot-plugins',
                                                    'Plugins',
-                                                   ),
-               'doorbot':          GithubRepository(
-                                                   'hacklab',
-                                                   'doorbot',
-                                                   ),
-               'boombot':          GithubRepository(
-                                                   'nod',
-                                                   'boombot',
-                                                   'plugins',
-                                                   ),
-               'mailed-notifier':  GithubRepository(
-                                                   'tbielawa',
-                                                   'supybot-mailed-notifier',
-                                                   ),
-               'pingdom':          GithubRepository(
-                                                   'rynop',
-                                                   'supyPingdom',
-                                                   'plugins',
-                                                   ),
-               'scrum':            GithubRepository(
-                                                   'amscanne',
-                                                   'supybot-scrum',
                                                    ),
                'Hoaas':            GithubRepository(
                                                    'Hoaas',
@@ -268,22 +214,10 @@ repositories = utils.InsensitivePreservingDict({
                                                    'nyuszika7h',
                                                    'limnoria-plugins'
                                                    ),
-               'nyuszika7h-old':   GithubRepository(
-                                                   'nyuszika7h',
-                                                   'Supybot-plugins'
-                                                   ),
-               'resistivecorpse':  GithubRepository(
-                                                   'resistivecorpse',
-                                                   'supybot-plugins'
-                                                   ),
                'frumious':         GithubRepository(
                                                    'frumiousbandersnatch',
                                                    'sobrieti-plugins',
                                                    'plugins',
-                                                   ),
-               'jonimoose':        GithubRepository(
-                                                   'Jonimoose',
-                                                   'Supybot-plugins',
                                                    ),
                'skgsergio':        GithubRepository(
                                                    'skgsergio',

--- a/plugins/PluginDownloader/plugin.py
+++ b/plugins/PluginDownloader/plugin.py
@@ -121,11 +121,11 @@ class GithubRepository(GitRepository):
         assert directory is not None, \
                 'No valid directory in supybot.directories.plugins.'
 
+        possibly_incompatible = False
         try:
             assert archive.getmember(prefix + dirname).isdir(), \
                 'This is not a valid plugin (it is a file, not a directory).'
 
-            run_2to3 = minisix.PY3
             for file in archive.getmembers():
                 if file.name.startswith(prefix + dirname):
                     extractedFile = archive.extractfile(file)
@@ -140,42 +140,18 @@ class GithubRepository(GitRepository):
                         os.mkdir(newFileName)
                     else:
                         with open(newFileName, 'ab') as fd:
-                            reload_imported = False
                             for line in extractedFile.readlines():
-                                if minisix.PY3:
-                                    if b'import reload' in line:
-                                        reload_imported = True
-                                    elif not reload_imported and \
-                                            b'reload(' in line:
-                                        fd.write(b'from importlib import reload\n')
-                                        reload_imported = True
+                                if file.name.endswith('__init__.py') and \
+                                        line.startswith((b'import config', b'import plugin')):
+                                    possibly_incompatible = True
                                 fd.write(line)
-                    if newFileName.endswith('__init__.py'):
-                        with open(newFileName) as fd:
-                            lines = list(filter(lambda x:'import plugin' in x,
-                                fd.readlines()))
-                            if lines and lines[0].startswith('from . import'):
-                                # This should be already Python 3-compatible
-                                run_2to3 = False
         finally:
             archive.close()
             del archive
-        if run_2to3:
-            try:
-                import lib2to3
-            except ImportError:
-                return _('Plugin is probably not compatible with your '
-                        'Python version (3.x) and could not be converted '
-                        'because 2to3 is not installed.')
-            import subprocess
-            fixers = []
-            subprocess.Popen(['2to3', '-wn', os.path.join(directory, plugin)]) \
-                    .wait()
-            return _('Plugin was designed for Python 2, but an attempt to '
-                    'convert it to Python 3 has been made. There is no '
-                    'guarantee it will work, though.')
-        else:
-            return _('Plugin successfully installed.')
+        if possibly_incompatible:
+            return _('Plugin installed. However, it may be incompatible with '
+                     'Python 3 and require manual code changes to work correctly.')
+        return _('Plugin successfully installed.')
 
     def getInfo(self, plugin):
         archive = self._download(plugin)

--- a/plugins/PluginDownloader/test.py
+++ b/plugins/PluginDownloader/test.py
@@ -29,11 +29,9 @@
 ###
 
 import os
-import sys
 import shutil
 
 from supybot.test import *
-import supybot.utils.minisix as minisix
 
 pluginsPath = '%s/test-plugins' % os.getcwd()
 
@@ -80,16 +78,14 @@ class PluginDownloaderTestCase(PluginTestCase):
         self.assertNotError('plugindownloader install Hoaas DuckDuckGo')
         self._testPluginInstalled('DuckDuckGo')
 
+    def testInstallLegacyWarning(self):
+        self.assertRegexp('plugindownloader install frumious Codepoints',
+                          'may be incompatible')
+
     def testInfo(self):
         self.assertResponse('plugindownloader info progval Twitter',
                 'Advanced Twitter plugin for Supybot, with capabilities '
                 'handling, and per-channel user account.')
-
-    if minisix.PY3:
-        def test_2to3(self):
-            self.assertRegexp('plugindownloader install SpiderDave Pastebin',
-                    'convert')
-            self.assertNotError('load Pastebin')
 
 if not network:
     class PluginDownloaderTestCase(PluginTestCase):

--- a/plugins/PluginDownloader/test.py
+++ b/plugins/PluginDownloader/test.py
@@ -62,7 +62,7 @@ class PluginDownloaderTestCase(PluginTestCase):
 
     def testRepolist(self):
         self.assertRegexp('repolist', '(.*, )?progval(, .*)?')
-        self.assertRegexp('repolist', '(.*, )?quantumlemur(, .*)?')
+        self.assertRegexp('repolist', '(.*, )?jlu5(, .*)?')
         self.assertRegexp('repolist progval', '(.*, )?AttackProtector(, .*)?')
 
     def testInstallprogval(self):
@@ -75,29 +75,6 @@ class PluginDownloaderTestCase(PluginTestCase):
         with conf.supybot.commands.allowShell.context(False):
             self.assertRegexp('plugindownloader install progval Darcs',
                     'Error:.*not available.*supybot.commands.allowShell')
-
-    def testInstallQuantumlemur(self):
-        self.assertError('plugindownloader install quantumlemur AttackProtector')
-        self.assertNotError('plugindownloader install quantumlemur Listener')
-        self.assertError('plugindownloader install quantumlemur AttackProtector')
-        self._testPluginInstalled('Listener')
-
-    def testInstallStepnem(self):
-        self.assertNotError('plugindownloader install stepnem Freenode')
-        self._testPluginInstalled('Freenode')
-
-    def testInstallNanotubeBitcoin(self):
-        self.assertNotError('plugindownloader install nanotube-bitcoin GPG')
-        self._testPluginInstalled('GPG')
-
-    def testInstallMtughanWeather(self):
-        self.assertNotError('plugindownloader install mtughan-weather '
-                            'WunderWeather')
-        self._testPluginInstalled('WunderWeather')
-
-    def testInstallSpiderDave(self):
-        self.assertNotError('plugindownloader install SpiderDave Pastebin')
-        self._testPluginInstalled('Pastebin')
 
     def testInstallNonAsciiInit(self):
         self.assertNotError('plugindownloader install Hoaas DuckDuckGo')


### PR DESCRIPTION
The repos I've selected for removal are those that at a cursory glance, appears to only include plugins supporting Python 2 (`import config` / `import plugin` in `__init__.py`). Unsurprisingly, most of these also haven't been updated in ~10 years.

I'm also removing the automatic 2to3 step because the current heuristic is buggy, and automated porting alone is unlikely to fix plugins that are this old anyways (obsolete web APIs etc.). Attempting to load plugins with the outdated import style will still suggest 2to3 in the error message, so the hint is still there for people who want to try.

On a side note, `lib2to3` is apparently being deprecated in Python 3.11: https://docs.python.org/3/library/2to3.html#module-lib2to3

