### PR TITLE
adding option to filter privmsg from unregistered users per network

### DIFF
--- a/src/callbacks.py
+++ b/src/callbacks.py
@@ -111,6 +111,14 @@ def _addressed(irc, msg, prefixChars=None, nicks=None,
     nicks.insert(0, ircutils.toLower(nick))
     # Ok, let's see if it's a private message.
     if ircutils.nickEqual(target, nick):
+        if get(conf.supybot.reply.unregistered) is False:
+            try:
+                user = ircdb.users.getUser(msg.prefix)
+            except KeyError:
+                log.info("ignoring %s from unregistered user %s (%s) on %s"
+                         " network: '%s'", msg.command, msg.nick, msg.prefix,
+                         network, msg.args[1])
+                return ''
         payload = stripPrefixStrings(payload)
         while payload and payload[0] in prefixChars:
             payload = payload[1:].lstrip()

--- a/src/conf.py
+++ b/src/conf.py
@@ -608,6 +608,10 @@ registerChannelValue(supybot.reply, 'requireChannelCommandsToBeSentInChannel',
     changes the behavior of the channel but was sent outside the channel
     itself.""")))
 
+registerNetworkValue(supybot.reply, 'unregistered',
+    registry.Boolean(True, _("""Determines whether we respond via private
+    messages to unregistered users.""")))
+
 registerGlobalValue(supybot, 'followIdentificationThroughNickChanges',
     registry.Boolean(False, _("""Determines whether the bot will unidentify
     someone when that person changes their nick.  Setting this to True


### PR DESCRIPTION
While running a relay bot when transitioning IRC networks I have found that I want little interaction with the bot on the old network. I can limit the channel interaction with the normal `supybot.reply.whenAddressedBy` settings. However, users can still interact with the bot via PRIVMSG.

This PR introduces a new network config option to allow the bot to ignore unregistered users (with logging of the action).  It's set to 'True' by default so no changes to users will be seen. If desired, a user can globally, or per-network, disable (set to False) the new `supybot.reply.unregistered` configuration value to ignore all interaction via PRIVMSG from unregistered users.