### PR TITLE
Services: allow adjusting GHOST command

### DIFF
--- a/plugins/Services/config.py
+++ b/plugins/Services/config.py
@@ -85,6 +85,10 @@ conf.registerNetworkValue(Services, 'noJoinsUntilIdentified',
 conf.registerNetworkValue(Services, 'ghostDelay',
     registry.NonNegativeInteger(60, _("""Determines how many seconds the bot will
     wait between successive GHOST attempts. Set this to 0 to disable GHOST.""")))
+conf.registerNetworkValue(Services, 'ghostCommand',
+    registry.String("GHOST", _("""Determines the NickServ command to use for GHOST. If the network
+    you're using runs Anope, set this to "RECOVER". If the network you're using runs Atheme,
+    set this to "GHOST" or "REGAIN".""")))
 conf.registerNetworkValue(Services, 'NickServ',
     ValidNickOrEmptyString('NickServ', _("""Determines what nick the 'NickServ' service
     has.""")))

--- a/plugins/Services/plugin.py
+++ b/plugins/Services/plugin.py
@@ -162,7 +162,8 @@ class Services(callbacks.Plugin):
         else:
             self.log.info('Sending ghost (current nick: %s; ghosting: %s)',
                           irc.nick, nick)
-            ghost = 'GHOST %s %s' % (nick, password)
+            ghostCommand = self.registryValue('ghostCommand', network=irc.network)
+            ghost = '%s %s %s' % (ghostCommand, nick, password)
             # Ditto about the sendMsg (see _doIdentify).
             irc.sendMsg(ircmsgs.privmsg(nickserv, ghost))
             state.sentGhost = time.time()
@@ -297,7 +298,7 @@ class Services(callbacks.Plugin):
         elif irc.isChannel(msg.args[0]):
             # Atheme uses channel-wide notices for alerting channel access
             # changes if the FANTASY or VERBOSE setting is on; we can suppress
-            # these 'unexpected notice' warnings since they're not really 
+            # these 'unexpected notice' warnings since they're not really
             # important.
             pass
         else:


### PR DESCRIPTION
Anope 2.x has renamed this to /ns recover

Closes GH-1510

Note: I haven't tested this because I don't really run my bot on that many networks anymore, and the original reporter didn't have time for it either. But it's a fairly simple change nonetheless...