### PR TITLE
utils.str: Handle \0 in perlReToReplacer

### DIFF
--- a/src/utils/str.py
+++ b/src/utils/str.py
@@ -298,7 +298,8 @@ def perlReToReplacer(s):
     regexp = regexp.replace('\x08', r'\b')
     replace = replace.replace('\\'+sep, sep)
     for i in range(10):
-        replace = replace.replace(chr(i), r'\%s' % i)
+        replace = replace.replace(chr(i), r'\g<%s>' % i)
+    replace = replace.replace(r'\0', r'\g<0>')
     g = False
     if 'g' in flags:
         g = True

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -311,6 +311,10 @@ class StrTest(SupyTestCase):
         self.assertEqual(f('foo'), 'foo/bar')
         f = PRTR('s/^/foo/')
         self.assertEqual(f('bar'), 'foobar')
+        f = PRTR('s/bar/foo\0/')
+        self.assertEqual(f('bar'), 'foobar')
+        f = PRTR(r's/bar/foo\0/')
+        self.assertEqual(f('bar'), 'foobar')
 
     def testMultipleReplacer(self):
         replacer = utils.str.MultipleReplacer({'foo': 'bar', 'a': 'b'})


### PR DESCRIPTION
It is required to use \g<0> as otherwise Python will process \0 as a 0 byte.

Previous behaviour:
```
<User> @re "s/hello/\0 world/" "hello"
<Bot> '\x00 world'
```