### PR TITLE
String: Fix exception on invalid group reference

### DIFF
--- a/plugins/String/plugin.py
+++ b/plugins/String/plugin.py
@@ -218,20 +218,21 @@ class String(callbacks.Plugin):
         s/regexp/replacement/flags, returns the result of applying such a
         regexp to <text>.
         """
-        if f('') and len(f(' ')) > len(f(''))+1: # Matches the empty string.
-            s = _('You probably don\'t want to match the empty string.')
-            irc.error(s)
-        else:
-            t = self.registryValue('re.timeout')
-            try:
-                v = process(f, text, timeout=t, pn=self.name(), cn='re')
-                if isinstance(v, list):
-                    v = format('%L', v)
-                irc.reply(v)
-            except commands.ProcessTimeoutError as e:
-                irc.error("ProcessTimeoutError: %s" % (e,))
-            except re.error as e:
-                irc.error(e.args[0])
+        try:
+            if f('') and len(f(' ')) > len(f(''))+1: # Matches the empty string.
+                s = _('You probably don\'t want to match the empty string.')
+                irc.error(s)
+            else:
+                t = self.registryValue('re.timeout')
+                try:
+                    v = process(f, text, timeout=t, pn=self.name(), cn='re')
+                    if isinstance(v, list):
+                        v = format('%L', v)
+                    irc.reply(v)
+                except commands.ProcessTimeoutError as e:
+                    irc.error("ProcessTimeoutError: %s" % (e,))
+        except re.error as e:
+            irc.error(e.args[0])
     re = thread(wrap(re, [first('regexpMatcherMany', 'regexpReplacer'),
                    'text']))
 


### PR DESCRIPTION
An re.error is raised when the function is called to check if trying to match the empty string.
Thus, move the try one level outside to cover that case as well.

Before:
```
<User> %re s/test/\1/ test
<Bot> An error has occurred and has been logged. Check the logs for more information.
```

After:
```
<User> %re s/test/\1/ test
<Bot> Error: invalid group reference 1 at position 1
```

Misc information
```
The current (running) version of this Limnoria is 2023.04.28, running on Python 3.8.10 (default, Mar 13 2023, 10:26:41)  [GCC 9.4.0].  The newest versions available online are 2023.01.28 (in master), 2023.04.28 (in testing).
```
```
ERROR 2023-05-12T15:07:01 supybot Uncaught exception in ['re'].
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/limnoria-2023.4.28-py3.8.egg/supybot/callbacks.py", line 1589, in _callCommand
    self.callCommand(command, irc, msg, *args, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/limnoria-2023.4.28-py3.8.egg/supybot/utils/python.py", line 91, in g
    f(self, *args, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/limnoria-2023.4.28-py3.8.egg/supybot/callbacks.py", line 1555, in callCommand
    method(irc, msg, *args, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/limnoria-2023.4.28-py3.8.egg/supybot/commands.py", line 76, in newf
    f(self, irc, msg, args, *L, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/limnoria-2023.4.28-py3.8.egg/supybot/commands.py", line 1163, in newf
    f(self, irc, msg, args, *state.args, **state.kwargs)
  File "/usr/local/lib/python3.8/dist-packages/limnoria-2023.4.28-py3.8.egg/supybot/plugins/String/plugin.py", line 221, in re
    if f('') and len(f(' ')) > len(f(''))+1: # Matches the empty string.
  File "/usr/local/lib/python3.8/dist-packages/limnoria-2023.4.28-py3.8.egg/supybot/utils/str.py", line 312, in <lambda>
    return lambda s: r.sub(replace, s, 1)
  File "/usr/lib/python3.8/re.py", line 327, in _subx
    template = _compile_repl(template, pattern)
  File "/usr/lib/python3.8/re.py", line 318, in _compile_repl
    return sre_parse.parse_template(repl, pattern)
  File "/usr/lib/python3.8/sre_parse.py", line 1036, in parse_template
    addgroup(int(this[1:]), len(this) - 1)
  File "/usr/lib/python3.8/sre_parse.py", line 980, in addgroup
    raise s.error("invalid group reference %d" % index, pos)
re.error: invalid group reference 1 at position 1
```