### PR TITLE
Route commands from Network.command back to the original network

### DIFF
--- a/plugins/Network/plugin.py
+++ b/plugins/Network/plugin.py
@@ -149,7 +149,7 @@ class Network(callbacks.Plugin):
 
         Gives the bot <command> (with its associated <arg>s) on <network>.
         """
-        self.Proxy(otherIrc, msg, commandAndArgs)
+        self.Proxy(otherIrc, msg, commandAndArgs, replyIrc=irc)
     command = wrap(command, ['admin', ('networkIrc', True), many('something')])
 
     def cmdall(self, irc, msg, args, commandAndArgs):

--- a/plugins/Network/test.py
+++ b/plugins/Network/test.py
@@ -31,7 +31,7 @@
 from supybot.test import *
 
 class NetworkTestCase(PluginTestCase):
-    plugins = ['Network', 'Utilities']
+    plugins = ['Network', 'Utilities', 'String', 'Misc']
     def testNetworks(self):
         self.assertNotError('networks')
 
@@ -39,6 +39,28 @@ class NetworkTestCase(PluginTestCase):
         self.assertResponse('network command %s echo 1' % self.irc.network,
                             '1')
 
+    def testCommandRoutesBackToCaller(self):
+        self.otherIrc = getTestIrc("testnet1")
+        # This will fail with timeout if the response never comes back
+        self.assertResponse(
+            'network command testnet1 echo $network', 'testnet1')
+
+    def testCommandRoutesErrorsBackToCaller(self):
+        self.otherIrc = getTestIrc("testnet2")
+        self.assertRegexp(
+            f'network command testnet2 re s/.*// test',
+            'I tried to send you an empty message')
+
+    def testCommandRoutesMoreBackToCaller(self):
+        self.otherIrc = getTestIrc("testnet3")
+        self.assertNotError('clearmores')
+        self.assertError('more')
+        self.assertRegexp(
+            f'network command testnet3 echo {"Hello"*300}',
+            r'Hello.*\(\d+ more messages\)')
+        self.assertRegexp(
+            'more',
+            r'Hello.*\(\d+ more messages\)')
 
 # vim:set shiftwidth=4 softtabstop=4 expandtab textwidth=79:
 

--- a/src/callbacks.py
+++ b/src/callbacks.py
@@ -640,8 +640,8 @@ class ReplyIrcProxy(RichReplyMethods):
     the reply() and error() methods (as well as everything in RichReplyMethods,
     based on those two).
 
-    If `replyIrc` is given in addition to `irc`, commands will be run on `irc`
-    but replies will be delivered to `replyIrc`. This is used by the Network
+    If ``replyIrc`` is given in addition to ``irc``, commands will be run on ``irc``
+    but replies will be delivered to ``replyIrc``. This is used by the Network
     plugin to run commands on other networks."""
     _mores = ircutils.IrcDict()
     def __init__(self, irc, msg, replyIrc=None):


### PR DESCRIPTION
Add a replyIrc parameter to ReplyIrcProxy to run a command on one network, but route the replies to another.

This fixes a long standing issue GH-556 where replies for remote commands are often lost to the void, as the nick of the caller may not exist on the target network (or worse, it could belong to a completely unrelated person).