### PR TITLE
Deprecate using supybot.dynamicScope without an import

### DIFF
--- a/plugins/Aka/plugin.py
+++ b/plugins/Aka/plugin.py
@@ -43,6 +43,7 @@ import supybot.ircutils as ircutils
 import supybot.callbacks as callbacks
 import supybot.httpserver as httpserver
 from supybot.i18n import PluginInternationalization
+from supybot.dynamicScope import dynamic
 _ = PluginInternationalization('Aka')
 
 try:

--- a/plugins/Factoids/plugin.py
+++ b/plugins/Factoids/plugin.py
@@ -44,6 +44,7 @@ import supybot.ircutils as ircutils
 import supybot.callbacks as callbacks
 import supybot.httpserver as httpserver
 from supybot.i18n import PluginInternationalization, internationalizeDocstring
+from supybot.dynamicScope import dynamic
 _ = PluginInternationalization('Factoids')
 
 import sqlite3

--- a/plugins/Google/plugin.py
+++ b/plugins/Google/plugin.py
@@ -42,6 +42,7 @@ import supybot.ircmsgs as ircmsgs
 import supybot.ircutils as ircutils
 import supybot.callbacks as callbacks
 from supybot.i18n import PluginInternationalization, internationalizeDocstring
+from supybot.dynamicScope import dynamic
 _ = PluginInternationalization('Google')
 
 from .parser import GoogleHTMLParser

--- a/plugins/Relay/plugin.py
+++ b/plugins/Relay/plugin.py
@@ -42,6 +42,7 @@ import supybot.ircutils as ircutils
 import supybot.callbacks as callbacks
 from supybot.utils.structures import MultiSet, TimeoutQueue
 from supybot.i18n import PluginInternationalization, internationalizeDocstring
+from supybot.dynamicScope import dynamic
 _ = PluginInternationalization('Relay')
 
 class Relay(callbacks.Plugin):

--- a/plugins/Success/plugin.py
+++ b/plugins/Success/plugin.py
@@ -33,6 +33,7 @@ from supybot.commands import *
 import supybot.plugins as plugins
 import supybot.ircutils as ircutils
 from supybot.i18n import PluginInternationalization, internationalizeDocstring
+from supybot.dynamicScope import dynamic
 _ = PluginInternationalization('Success')
 
 class Success(plugins.ChannelIdDatabasePlugin):

--- a/src/callbacks.py
+++ b/src/callbacks.py
@@ -45,6 +45,7 @@ import warnings
 
 from . import (conf, ircdb, irclib, ircmsgs, ircutils, log, registry,
         utils, world)
+from .dynamicScope import dynamic
 from .utils import minisix
 from .utils.iter import any, all
 from .i18n import PluginInternationalization

--- a/src/commands.py
+++ b/src/commands.py
@@ -46,6 +46,7 @@ except ImportError: # Windows!
 
 from . import callbacks, conf, ircdb, ircmsgs, ircutils, log, \
         utils, world
+from .dynamicScope import dynamic
 from .utils import minisix
 from .i18n import PluginInternationalization, internationalizeDocstring
 _ = PluginInternationalization()

--- a/src/conf.py
+++ b/src/conf.py
@@ -36,6 +36,7 @@ import socket
 import random
 
 from . import ircutils, registry, utils
+from .dynamicScope import dynamic
 from .utils import minisix
 from .utils.net import isSocketAddress
 from .version import version

--- a/src/dynamicScope.py
+++ b/src/dynamicScope.py
@@ -28,6 +28,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 ###
 
+import logging
 import sys
 
 class DynamicScope(object):
@@ -48,6 +49,18 @@ class DynamicScope(object):
     def __setattr__(self, name, value):
         self._getLocals(name)[name] = value
 
-(__builtins__ if isinstance(__builtins__, dict) else __builtins__.__dict__)['dynamic'] = DynamicScope()
+class _DynamicScopeBuiltinsWrapper(DynamicScope):
+    def __getattr__(self, name):
+        _logger = logging.getLogger('supybot')
+        _logger.warning('Using DynamicScope without an explicit import is '
+                        'deprecated and will be removed in a future Limnoria '
+                        'version. Use instead: '
+                        'from supybot.dynamicScope import dynamic',
+                        stacklevel=2, stack_info=True)
+        return super().__getattr__(name)
+
+dynamic = DynamicScope()
+(__builtins__ if isinstance(__builtins__, dict) else __builtins__.__dict__)['dynamic'] = \
+    _DynamicScopeBuiltinsWrapper()
 
 # vim:set shiftwidth=4 softtabstop=4 expandtab textwidth=79:

--- a/src/log.py
+++ b/src/log.py
@@ -86,10 +86,9 @@ class Logger(logging.Logger):
         # The traceback should be sufficient if we want it.
         # self.error('Exception string: %s', eStrId)
 
-    def _log(self, level, msg, args, exc_info=None, extra=None):
+    def _log(self, level, msg, args, **kwargs):
         msg = format(msg, *args)
-        logging.Logger._log(self, level, msg, (), exc_info=exc_info, 
-                            extra=extra)
+        logging.Logger._log(self, level, msg, (), **kwargs)
 
 
 class StdoutStreamHandler(logging.StreamHandler):

--- a/test/test_dynamicScope.py
+++ b/test/test_dynamicScope.py
@@ -28,6 +28,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 ###
 
+from supybot.dynamicScope import dynamic
 from supybot.test import *
 
 class TestDynamic(SupyTestCase):


### PR DESCRIPTION
Some notes:
- I'm using UserWarning here because Python doesn't show DeprecationWarnings to the console by default. (I'm not sure if changing that would be a better option)