### PR TITLE
ircdb.checkIgnored: return False for messages from servers

### DIFF
--- a/src/ircdb.py
+++ b/src/ircdb.py
@@ -468,7 +468,12 @@ class IrcChannel(object):
             return True
         if world.testing:
             return False
-        assert ircutils.isUserHostmask(hostmask), 'got %s' % hostmask
+        if not ircutils.isUserHostmask(hostmask):
+            # Treat messages from a server (e.g. snomasks) as not ignored, as
+            # the ignores system doesn't understand them
+            if '.' not in hostmask:
+                raise ValueError("Expected full prefix, got %r" % hostmask)
+            return False
         if self.checkBan(hostmask):
             return True
         if self.ignores.match(hostmask):

--- a/test/test_ircdb.py
+++ b/test/test_ircdb.py
@@ -350,6 +350,23 @@ class IrcChannelTestCase(IrcdbTestCase):
         c.removeBan(banmask)
         self.assertFalse(c.checkIgnored(prefix))
 
+        # Only full n!u@h is accepted here
+        self.assertRaises(ValueError, c.checkIgnored, 'foo')
+
+    def testIgnoredServerNames(self):
+        c = ircdb.IrcChannel()
+        # Server names are not handled by the ignores system, so this is false
+        self.assertFalse(c.checkIgnored('irc.example.com'))
+        # But we should treat full prefixes that match nick!user@host normally,
+        # even if they include "." like a server name
+        prefix = 'irc.example.com!bar@baz'
+        banmask = ircutils.banmask(prefix)
+        self.assertFalse(c.checkIgnored(prefix))
+        c.addIgnore(banmask)
+        self.assertTrue(c.checkIgnored(prefix))
+        c.removeIgnore(banmask)
+        self.assertFalse(c.checkIgnored(prefix))
+
 class IrcNetworkTestCase(IrcdbTestCase):
     def testDefaults(self):
         n = ircdb.IrcNetwork()


### PR DESCRIPTION
These do not pass the `ircutils.isUserHostmask` check despite being a valid `msg.prefix`. We should probably return gracefully here instead of forcing plugins to deal with such a case themselves.

Closes GH-1548