### PR TITLE
Keep line-endings normalized & configure text editors to follow Limnoria style guidelines

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+max_line_length = 79

--- a/.editorconfig
+++ b/.editorconfig
@@ -3,5 +3,7 @@ root = true
 [*]
 insert_final_newline = true
 indent_style = space
+
+[*.py]
 indent_size = 4
 max_line_length = 79

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
+* text=auto
 sandbox export-ignore
 .git* export-ignore


### PR DESCRIPTION
As `.gitattributes` was already there I thought it might be a good idea to add end-of-line normalization of git from this decade.

- https://www.git-scm.com/docs/gitattributes#_end_of_line_conversion

-----

When writing #1560, I noticed that my `nvim` was making tabs which is against Limnoria's style guidelines. Thus I added `.editorconfig` that follows the [Limnoria style guidelines](https://limnoria.readthedocs.io/en/latest/develop/style.html) so [supported editors and plugins](https://editorconfig.org/#pre-installed) will automatically attempt to use four spaces as indentation and stay within 79 lines.

I am not sure if I should add it to `.gitattributes` as `export-ignore`, because someone could download the repository archive and send a patch by email or pastebin and thus benefit from `.editorconfig` being present.

I think copying it to repositories containing plugins would also be a good idea.