### PR TITLE
Ignore trailing whitespace when addressing the bot by nick at end

### DIFF
--- a/plugins/Misc/test.py
+++ b/plugins/Misc/test.py
@@ -252,11 +252,6 @@ class MiscTestCase(ChannelPluginTestCase):
         finally:
             nickConfig.setValue(orig)
 
-    def testWhenAddressedByNickAtEnd(self):
-        nick = ircutils.nickFromHostmask(self.prefix)
-        self.assertResponse("jaldkfjkdlaljf %s  \t" %nick,
-                "Error: \"jaldkfjkdlaljf\" is not a valid command.")
-
     def testMore(self):
         self.assertResponse('echo %s' % ('abc '*400),
                             'abc '*112 + ' \x02(3 more messages)\x02')

--- a/plugins/Misc/test.py
+++ b/plugins/Misc/test.py
@@ -252,6 +252,11 @@ class MiscTestCase(ChannelPluginTestCase):
         finally:
             nickConfig.setValue(orig)
 
+    def testWhenAddressedByNickAtEnd(self):
+        nick = ircutils.nickFromHostmask(self.prefix)
+        self.assertResponse("jaldkfjkdlaljf %s  \t" %nick,
+                "Error: \"jaldkfjkdlaljf\" is not a valid command.")
+
     def testMore(self):
         self.assertResponse('echo %s' % ('abc '*400),
                             'abc '*112 + ' \x02(3 more messages)\x02')

--- a/src/callbacks.py
+++ b/src/callbacks.py
@@ -136,8 +136,8 @@ def _addressed(irc, msg, prefixChars=None, nicks=None,
                         continue
                 except ValueError: # split didn't work.
                     continue
-            elif whenAddressedByNickAtEnd and lowered.endswith(nick):
-                rest = payload[:-len(nick)]
+            elif whenAddressedByNickAtEnd and lowered.rstrip().endswith(nick):
+                rest = payload.rstrip()[:-len(nick)]
                 possiblePayload = rest.rstrip(' \t,;')
                 if possiblePayload != rest:
                     # There should be some separator between the nick and the

--- a/test/test_callbacks.py
+++ b/test/test_callbacks.py
@@ -269,7 +269,6 @@ class FunctionsTestCase(SupyTestCase):
         irc = getTestIrc()
         msg = ircmsgs.privmsg('#foo', 'baz, bar')
         irc._tagMsg(msg)
-        nick = irc.nick
         self.assertEqual(callbacks.addressed('bar', msg,
                                              whenAddressedByNickAtEnd=True),
                          'baz')

--- a/test/test_callbacks.py
+++ b/test/test_callbacks.py
@@ -201,6 +201,11 @@ class FunctionsTestCase(SupyTestCase):
         badmsg = ircmsgs.privmsg('#foo', '%s`: foo' % nick)
         self.assertFalse(callbacks.addressed(irc, badmsg))
 
+    def testWhenAddressedByNickAtEnd(self):
+        nick = ircutils.nickFromHostmask(self.prefix)
+        self.assertResponse("jaldkfjkdlaljf %s  \t" %nick,
+                "Error: \"jaldkfjkdlaljf\" is not a valid command.")
+
     def testAddressedLegacy(self):
         """Checks callbacks.addressed still accepts the 'nick' argument
         instead of 'irc'."""

--- a/test/test_callbacks.py
+++ b/test/test_callbacks.py
@@ -201,11 +201,6 @@ class FunctionsTestCase(SupyTestCase):
         badmsg = ircmsgs.privmsg('#foo', '%s`: foo' % nick)
         self.assertFalse(callbacks.addressed(irc, badmsg))
 
-    def testWhenAddressedByNickAtEnd(self):
-        nick = ircutils.nickFromHostmask(self.prefix)
-        self.assertResponse("jaldkfjkdlaljf %s  \t" %nick,
-                "Error: \"jaldkfjkdlaljf\" is not a valid command.")
-
     def testAddressedLegacy(self):
         """Checks callbacks.addressed still accepts the 'nick' argument
         instead of 'irc'."""
@@ -274,9 +269,16 @@ class FunctionsTestCase(SupyTestCase):
         irc = getTestIrc()
         msg = ircmsgs.privmsg('#foo', 'baz, bar')
         irc._tagMsg(msg)
+        nick = irc.nick
         self.assertEqual(callbacks.addressed('bar', msg,
                                              whenAddressedByNickAtEnd=True),
                          'baz')
+        # Test that it still works with trailing whitespace:
+        msg = ircmsgs.privmsg('#foo', 'baz, bar   \t')
+        self.assertEqual(callbacks.addressed('bar', msg,
+                                             whenAddressedByNickAtEnd=True),
+                         'baz')
+
 
     def testAddressedPrefixCharsTakePrecedenceOverNickAtEnd(self):
         irc = getTestIrc()


### PR DESCRIPTION
Seems to fix https://github.com/progval/Limnoria/issues/1455 

Again, if you decide to merge, please add the `hacktoberfest-accepted` label.