### PR TITLE
Fix: Ignore trailing chars/spaces for Karma

### DIFF
--- a/plugins/Karma/plugin.py
+++ b/plugins/Karma/plugin.py
@@ -272,7 +272,7 @@ class Karma(callbacks.Plugin):
         karma = ''
         for s in inc:
             if thing.endswith(s):
-                thing = thing[:-len(s)]
+                thing = thing[:-len(s)].rstrip(",:\t ")
                 # Don't reply if the target isn't a nick
                 if onlynicks and thing.lower() not in map(ircutils.toLower,
                         irc.state.channels[channel].users):
@@ -286,7 +286,7 @@ class Karma(callbacks.Plugin):
                 karma = self.db.get(channel, self._normalizeThing(thing))
         for s in dec:
             if thing.endswith(s):
-                thing = thing[:-len(s)]
+                thing = thing[:-len(s)].rstrip(",:\t ")
                 if onlynicks and thing.lower() not in map(ircutils.toLower,
                         irc.state.channels[channel].users):
                     return

--- a/plugins/Karma/test.py
+++ b/plugins/Karma/test.py
@@ -60,6 +60,10 @@ class KarmaTestCase(ChannelPluginTestCase):
                           'Karma for [\'"]moo[\'"].*increased 1.*total.*1')
         self.assertRegexp('karma MoO',
                           'Karma for [\'"]MoO[\'"].*increased 1.*total.*1')
+        # Test trailing characters and spaces
+        self.assertNoResponse('baz, 	++', 2)
+        self.assertRegexp('karma baz',
+                          'Karma for [\'"]baz[\'"].*increased 1.*total.*1')
 
     def testKarmaRankingDisplayConfigurable(self):
         try:


### PR DESCRIPTION
The trailing characters `,` and `:` have been chosen as they are the most popular ones appended to tab completed nicks.


Solves #1495 
