### PR TITLE
Add config value supybot.reply.mores.instant.whenPrivate

### DIFF
--- a/src/callbacks.py
+++ b/src/callbacks.py
@@ -769,6 +769,9 @@ class ReplyIrcProxy(RichReplyMethods):
         else:
             sendMsg = self.replyIrc.queueMsg
 
+        public = bool(self.msg.channel)
+        private = kwargs.get('private', False) or not public
+
         if isinstance(self.replyIrc, self.__class__):
             s = s[:conf.supybot.reply.maximumLength()]
             return self.replyIrc.reply(s,
@@ -813,8 +816,14 @@ class ReplyIrcProxy(RichReplyMethods):
             # (which is used like a stack)
             chunks.reverse()
 
-            instant = conf.get(conf.supybot.reply.mores.instant,
-                channel=target, network=self.replyIrc.network)
+            instant = 0
+            if private:
+                # if zero, falls back to supybot.reply.mores.instant
+                instant = conf.get(conf.supybot.reply.mores.instant.whenPrivate,
+                    network=self.replyIrc.network)
+            if instant <= 0:
+                instant = conf.get(conf.supybot.reply.mores.instant,
+                    channel=target, network=self.replyIrc.network)
 
             # Big complex loop ahead, with lots of cases and opportunities for
             # off-by-one errors. Here is the meaning of each of the variables
@@ -912,8 +921,6 @@ class ReplyIrcProxy(RichReplyMethods):
             if '!' in prefix and '@' in prefix:
                 mask = prefix.split('!', 1)[1]
                 self._mores[mask] = msgs
-            public = bool(self.msg.channel)
-            private = kwargs.get('private', False) or not public
             self._mores[msg.nick] = (private, msgs)
             return response
 

--- a/src/conf.py
+++ b/src/conf.py
@@ -547,6 +547,13 @@ registerChannelValue(supybot.reply.mores, 'instant',
     they are formed).  Defaults to 1, which means that a more command will be
     required for all but the first chunk.""")))
 
+# XXX: User value.
+registerNetworkValue(supybot.reply.mores.instant, 'whenPrivate',
+    registry.NonNegativeInteger(0, _("""Determines how many mores will be sent
+    instantly (i.e., without the use of the more command, immediately when
+    they are formed) when sending messages in private.  Defaults to 0, which means
+    that it defaults to the generic supybot.reply.mores.instant value.""")))
+
 registerChannelValue(supybot.reply, 'oneToOne',
     registry.Boolean(True, _("""Determines whether the bot will send
     multi-message replies in a single message. This defaults to True 


### PR DESCRIPTION
This allows overriding supybot.reply.mores.instant for private messages, where it is usually more tolerable to send multiple lines.

However, this still defaults to 1, in order to not be abusable by default.