### PR TITLE
[Unix] fix: add space to avoid breaking ipv6 formating

### DIFF
--- a/plugins/Unix/plugin.py
+++ b/plugins/Unix/plugin.py
@@ -332,8 +332,8 @@ class Unix(callbacks.Plugin):
                 else:
                     response = result[0].decode('utf8').split("\n");
                     if response[1]:
-                        irc.reply(' '.join(response[1].split()[3:5]).split(':')[0]
-                                  + ': ' + ' '.join(response[-3:]))
+                        irc.reply(' '.join(response[1].split()[3:5]).split(': ')[0]
+                                  + ' ' + ' '.join(response[-3:]))
                     else:
                         irc.reply(' '.join(response[0].split()[1:3])
                                   + ': ' + ' '.join(response[-3:]))


### PR DESCRIPTION
## Goal

This PR just add a space in a split to avoid splitting string on first `:` occurence inside an IPv6 with the `ping` command.