### PR TITLE
registry: Avoid calling Value.setValue() when closing registry

### DIFF
--- a/src/registry.py
+++ b/src/registry.py
@@ -148,7 +148,12 @@ def close(registry, filename, private=True):
                 if value._showDefault:
                     lines.append('#\n')
                     try:
-                        x = value.__class__(value._default, value._help)
+                        # We set setDefault to False and manually call
+                        # Value._setValue, just in case the class inherits
+                        # Value.setValue to set some global state (#1349)
+                        x = value.__class__(value._default, value._help,
+                            setDefault=False)
+                        x._setValue(value._default, inherited=False)
                     except Exception as e:
                         exception('Exception instantiating default for %s:' %
                                   value._name)

--- a/src/registry.py
+++ b/src/registry.py
@@ -153,7 +153,7 @@ def close(registry, filename, private=True):
                         # Value.setValue to set some global state (#1349)
                         x = value.__class__(value._default, value._help,
                             setDefault=False)
-                        x._setValue(value._default, inherited=False)
+                        x.value = value._default
                     except Exception as e:
                         exception('Exception instantiating default for %s:' %
                                   value._name)

--- a/test/test_registry.py
+++ b/test/test_registry.py
@@ -224,6 +224,24 @@ class ValuesTestCase(SupyTestCase):
             registry.open_registry(filename)
             self.assertEqual(conf.supybot.networks.test.password(), ' foo ')
 
+    def testSetValueUncalledOnClose(self):
+        values_set = 0
+        class StringWithSetLogging(registry.String):
+            def setValue(self, v):
+                nonlocal values_set
+                values_set += 1
+
+                super(StringWithSetLogging, self).setValue(v)
+
+        group = registry.Group()
+        group.setName('group')
+        conf.registerGlobalValue(group, 'string', StringWithSetLogging('test', 'help'))
+        group.string.set('mrrp')
+
+        filename = conf.supybot.directories.conf.dirize('setvaluecalls.conf')
+        registry.close(group, filename)
+        self.assertEqual(values_set, 2)
+
     def testReload(self):
         import supybot.world as world
         with conf.supybot.reply.whenAddressedBy.chars.context('@'):


### PR DESCRIPTION
Fixes #1349