### PR TITLE
Add support for negative integers options following getopt

### DIFF
--- a/src/commands.py
+++ b/src/commands.py
@@ -1070,7 +1070,17 @@ class getopts(context):
     def __call__(self, irc, msg, args, state):
         if LOG_CONVERTERS:
             log.debug('args before %r: %r', self, args)
-        (optlist, rest) = getopt.getopt(args, self.getoptLs, self.getoptL)
+
+        # look for the first '--' token, it forcefully ends the getopt list,
+        # which allows the next arguments to start with a -
+        try:
+            sep = args.index('--')
+        except ValueError:
+            sep = None
+        else:
+            log.debug('getopt stopping at "--" token at position %d', sep)
+
+        (optlist, rest) = getopt.getopt(args[:sep], self.getoptLs, self.getoptL)
         getopts = []
         for (opt, arg) in optlist:
             if opt.startswith('--'):
@@ -1088,7 +1098,11 @@ class getopts(context):
             else:
                 getopts.append((opt, True))
         state.args.append(getopts)
-        args[:] = rest
+
+        if sep is None:
+            args[:] = rest
+        else:
+            args[:sep+1] = rest
         if LOG_CONVERTERS:
             log.debug('args after %r: %r', self, args)
 

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -135,6 +135,26 @@ class GeneralContextTestCase(CommandsTestCase):
         self.assertRaises(getopt.GetoptError, self.assertStateErrored,
                          spec, ['12', '--f', 'baz', '--ba', '13', '15'])
 
+    def testGetoptsMinusInValue(self):
+        spec = ['int', getopts({'foo': None, 'bar': 'int'}), 'int']
+        self.assertState(spec,
+                         ['12', '--foo', 'baz', '--bar', '-13', '15'],
+                         [12, [('foo', 'baz'), ('bar', -13)], 15])
+
+    def testGetoptsMinusInNextArg(self):
+        spec = ['int', getopts({'foo': None, 'bar': 'int'}), 'int']
+
+        with self.assertRaises(
+                getopt.GetoptError, msg='option -1 not recognized'):
+            self.assertState(spec,
+                             ['12', '--foo', 'baz', '--bar', '13', '-15'],
+                             [])
+
+        self.assertState(spec,
+                         ['12', '--foo', 'baz', '--bar', '13', '--', '-15'],
+                         [12, [('foo', 'baz'), ('bar', 13)], -15])
+
+
     def testAny(self):
         self.assertState([any('int')], ['1', '2', '3'], [[1, 2, 3]])
         self.assertState([None, any('int')], ['1', '2', '3'], ['1', [2, 3]])


### PR DESCRIPTION
For example, this allows giving negative GPS coordinations to [`NuWeather`'s `@weather` command](https://github.com/jlu5/Limnoria-NuWeather/blob/18b9cbc8d8a04fda405a9e50d0b1dd3c216ecae9/plugin.py#L520-L522):

```py
    @wrap([getopts({'user': 'nick', 'backend': None, 'weather-backend': None, 'geocode-backend': None, 'forecast': ''}), additional('text')])
    def weather(self, irc, msg, args, optlist, location):
        """[--user <othernick>] [--weather-backend/--backend <weather backend>] [--geocode-backend <geocode backend>] [--forecast] [<location>]
```