### PR TITLE
Fix interference of wrap() and internationalizeDocstring()

### DIFF
--- a/src/i18n.py
+++ b/src/i18n.py
@@ -272,7 +272,7 @@ class _PluginInternationalization:
         try:
             string = self._translate(normalizedUntranslated)
         except KeyError:
-            string = untranslated
+            string = originalUntranslated
         return self._addTracker(string, untranslated)
 
     def _translate(self, string):

--- a/src/i18n.py
+++ b/src/i18n.py
@@ -1,5 +1,5 @@
 ###
-# Copyright (c) 2010-2021, Valentin Lorentz
+# Copyright (c) 2010-2024, Valentin Lorentz
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -263,15 +263,14 @@ class _PluginInternationalization:
         """Main function.
 
         This is the function which is called when a plugin runs _()"""
+        if untranslated.__class__ is InternationalizedString:
+            untranslated = untranslated._origin
+
         normalizedUntranslated = normalize(untranslated, True)
         try:
             string = self._translate(normalizedUntranslated)
             return self._addTracker(string, untranslated)
         except KeyError:
-            pass
-        if untranslated.__class__ is InternationalizedString:
-            return untranslated._original
-        else:
             return untranslated
 
     def _translate(self, string):

--- a/src/i18n.py
+++ b/src/i18n.py
@@ -264,7 +264,7 @@ class _PluginInternationalization:
 
         This is the function which is called when a plugin runs _()"""
         if untranslated.__class__ is InternationalizedString:
-            untranslated = untranslated._origin
+            untranslated = untranslated._original
 
         normalizedUntranslated = normalize(untranslated, True)
         try:

--- a/src/i18n.py
+++ b/src/i18n.py
@@ -264,14 +264,16 @@ class _PluginInternationalization:
 
         This is the function which is called when a plugin runs _()"""
         if untranslated.__class__ is InternationalizedString:
-            untranslated = untranslated._original
+            originalUntranslated = untranslated._original
+        else:
+            originalUntranslated = untranslated
 
-        normalizedUntranslated = normalize(untranslated, True)
+        normalizedUntranslated = normalize(originalUntranslated, True)
         try:
             string = self._translate(normalizedUntranslated)
-            return self._addTracker(string, untranslated)
         except KeyError:
-            return untranslated
+            string = untranslated
+        return self._addTracker(string, untranslated)
 
     def _translate(self, string):
         """Translate the string.


### PR DESCRIPTION
Most commands are decorated with @internationalizeDocstring then with wrap(). wrap() itself calls internationalizeDocstring(), so that plugins wrapping with @internationalizeDocstring() is now optional; but many still do it.

This means that docstrings went twice through the
_PluginInternationalization.

This fixes the bug that on the second run, it would try to translate again the translated message, which fails (because the translated message is not in English); and then fell back to the original string (which is in English).

This commit changes the behavior to return the already-translated string directly instead.