### PR TITLE
Added --random flag for 'rss' command

### DIFF
--- a/plugins/RSS/plugin.py
+++ b/plugins/RSS/plugin.py
@@ -36,6 +36,7 @@ import json
 import time
 import types
 import string
+import random
 import socket
 import threading
 import feedparser
@@ -170,6 +171,8 @@ def sort_feed_items(items, order):
     """Return feed items, sorted according to sortFeedItems."""
     if order == 'asInFeed':
         return items
+    elif order == 'random':
+        return random.shuffle(items)
     (key, reverse) = _sort_arguments(order)
     try:
         sitems = sorted(items, key=key, reverse=reverse)
@@ -695,11 +698,12 @@ class RSS(callbacks.Plugin):
         channels = wrap(channels, ['feedName'])
 
     @internationalizeDocstring
-    def rss(self, irc, msg, args, url, n):
-        """<name|url> [<number of headlines>]
+    def rss(self, irc, msg, args, optlist, url, n):
+        """[--random] <name|url> [<number of headlines>]
 
         Gets the title components of the given RSS feed.
         If <number of headlines> is given, return only that many headlines.
+        Use --random flag for random sorting of entries.
         """
         self.log.debug('Fetching %u', url)
         try:
@@ -719,17 +723,22 @@ class RSS(callbacks.Plugin):
                 s += str(feed.last_exception)
             irc.error(s)
             return
-        n = n or self.registryValue('defaultNumberOfHeadlines', channel, irc.network)
         entries = list(filter(lambda e:self.should_send_entry(irc.network, channel, e),
                               feed.entries))
-        entries = sort_feed_items(entries, 'newestFirst')
+        upper_sort = 'newestFirst'
+        if [y for x,y in optlist if x == 'random']:
+            upper_sort = 'random'
+        entries = sort_feed_items(entries, upper_sort)
+        n = n or self.registryValue('defaultNumberOfHeadlines', channel, irc.network)
         entries = entries[:n]
         entries = sort_feed_items(entries, self.registryValue('sortFeedItems'))
         headlines = map(lambda e:self.format_entry(irc.network, channel, feed, e, False),
                         entries)
         sep = self.registryValue('headlineSeparator', channel, irc.network)
         irc.replies(headlines, joiner=sep)
-    rss = wrap(rss, [first('url', 'feedName'), additional('int')])
+    rss = wrap(rss, [getopts({ 'random': '', }),
+                     first('url', 'feedName'),
+                     additional('int')])
 
     @internationalizeDocstring
     def info(self, irc, msg, args, url):

--- a/plugins/RSS/plugin.py
+++ b/plugins/RSS/plugin.py
@@ -172,7 +172,8 @@ def sort_feed_items(items, order):
     if order == 'asInFeed':
         return items
     elif order == 'random':
-        return random.shuffle(items)
+        random.shuffle(items)
+        return items
     (key, reverse) = _sort_arguments(order)
     try:
         sitems = sorted(items, key=key, reverse=reverse)

--- a/plugins/RSS/plugin.py
+++ b/plugins/RSS/plugin.py
@@ -726,10 +726,10 @@ class RSS(callbacks.Plugin):
             return
         entries = list(filter(lambda e:self.should_send_entry(irc.network, channel, e),
                               feed.entries))
-        upper_sort = 'newestFirst'
-        if [y for x,y in optlist if x == 'random']:
-            upper_sort = 'random'
-        entries = sort_feed_items(entries, upper_sort)
+        order = 'newestFirst'
+        if 'random' in (k for k,v in optlist):
+            order = 'random'
+        entries = sort_feed_items(entries, order)
         n = n or self.registryValue('defaultNumberOfHeadlines', channel, irc.network)
         entries = entries[:n]
         entries = sort_feed_items(entries, self.registryValue('sortFeedItems'))

--- a/plugins/RSS/test.py
+++ b/plugins/RSS/test.py
@@ -571,6 +571,12 @@ class RSSTestCase(ChannelPluginTestCase):
             m = self.assertNotError('rss %s 2' % url)
             self.assertEqual(m.args[1].count(' | '), 1)
 
+        def testRssRandom(self):
+            timeFastForward(1.1)
+            self.assertNotError('rss --random %s' % url)
+            m = self.assertNotError('rss --random %s 2' % url)
+            self.assertEqual(m.args[1].count(' | '), 1)
+
         def testRssAdd(self):
             timeFastForward(1.1)
             self.assertNotError('rss add advogato %s' % url)


### PR DESCRIPTION
Added `--random` flag for 'rss' command. It is randomizing initial order of rss entries. So you get random entry of given rss feed after every new call with this flag.

Fixes #1593.