### PR TITLE
Added oEmbed support to the Web plugin to improve title fetching

### DIFF
--- a/plugins/Web/config.py
+++ b/plugins/Web/config.py
@@ -95,4 +95,12 @@ conf.registerGlobalValue(Web.fetch, 'timeout',
     seconds the bot will wait for the site to respond, when using the 'fetch'
     command in this plugin. If 0, will use socket.defaulttimeout"""))
 
+conf.registerGlobalValue(Web, 'useOembedRegistry',
+    registry.Boolean(False, _("""Determines whether the bot will use the 
+    oembed.com providers registry.""")))
+
+conf.registerGlobalValue(Web, 'useOembedDiscovery',
+    registry.Boolean(False, _("""Determines whether the bot will use HTML
+    discovery to find oEmbed endpoints.""")))
+
 # vim:set shiftwidth=4 softtabstop=4 expandtab textwidth=79:

--- a/plugins/Web/plugin.py
+++ b/plugins/Web/plugin.py
@@ -489,10 +489,13 @@ class Web(callbacks.PluginRegexp):
         if not self._checkURLWhitelist(url):
             irc.error("This url is not on the whitelist.")
             return
-        r = self.getTitle(irc, url, True, msg)
-        if not r:
-            return
-        (target, title) = r
+        title = self.getOEmbedTitle(url)
+        target = url
+        if not title:
+            r = self.getTitle(irc, url, True, msg)
+            if not r:
+                return
+            (target, title) = r
         if title:
             if not [y for x,y in optlist if x == 'no-filter']:
                 for i in range(1, 4):

--- a/plugins/Web/test.py
+++ b/plugins/Web/test.py
@@ -179,6 +179,31 @@ class WebTestCase(ChannelPluginTestCase):
                 conf.supybot.plugins.Web.urlWhitelist.set('')
                 conf.supybot.plugins.Web.fetch.maximum.set(fm)
 
+        def testtitleOembedRegistry(self):
+            try:
+                conf.supybot.plugins.Web.useOembedRegistry.setValue(True)
+                self.assertResponse(
+                    'title https://www.flickr.com/photos/bees/2362225867/',
+                    'Bacon Lollys')
+            finally:
+                conf.supybot.plugins.Web.useOembedRegistry.setValue(False)
+
+        def testtitleOembedDiscovery(self):
+            try:
+                conf.supybot.plugins.Web.useOembedDiscovery.setValue(True)
+                self.assertResponse(
+                    'title https://flickr.com/photos/bees/2362225867/',
+                    'Bacon Lollys')
+            finally:
+                conf.supybot.plugins.Web.useOembedDiscovery.setValue(False)
+
+        def testtitleOembedError(self):
+            try:
+                conf.supybot.plugins.Web.useOembedDiscovery.setValue(True)
+                self.assertError('title https://nonexistent.example.com/post/123')
+            finally:
+                conf.supybot.plugins.Web.useOembedDiscovery.setValue(False)
+
     def testNonSnarfingRegexpConfigurable(self):
         self.assertSnarfNoResponse('http://foo.bar.baz/', 2)
         try:


### PR DESCRIPTION
Two methods are supported and can be configured:
1. Registry lookup via oembed.com (useOembedRegistry)
2. HTML discovery of endpoints (useOembedDiscovery)

Registry is tried first if enabled, then discovery if enabled,
finally falling back to HTML parsing.



_I think it would be nicer to add the calls to `getTitle()`._
_I was trying to avoid using `url_workaround()`, since it would break support for reddit - for exsample, old.reddit.com isn't in the registry. However, following redirects could actually be beneficial, especially for handling v.reddit.com._
_For discovery, it makes sense to place this logic close to the title parser, as that would save an extra request. That said, I wanted to open the pull request first to gather some feedback before making further adjustments._
