### PR TITLE
ChannelStats: Fix crash caused by expectation of __str__ being called before setValue

### DIFF
--- a/plugins/ChannelStats/config.py
+++ b/plugins/ChannelStats/config.py
@@ -45,6 +45,10 @@ def configure(advanced):
     conf.registerPlugin('ChannelStats', True)
 
 class Smileys(registry.Value):
+    def __init__(self, *args, **kwargs):
+        self.s = ''
+        super().__init__(*args, **kwargs)
+
     def set(self, s):
         L = s.split()
         self.setValue(L)


### PR DESCRIPTION
This assumption no longer true since #1601.

Resolves #1604.