### PR TITLE
NickAuth: refer to "services accounts" instead of "nicks" in help

### DIFF
--- a/plugins/NickAuth/test.py
+++ b/plugins/NickAuth/test.py
@@ -128,7 +128,7 @@ class NickAuthTestCase(PluginTestCase):
 
     def testList(self):
         self.assertNotError('register foobar 123')
-        self.assertRegexp('nick list', 'You have no recognized nick')
+        self.assertRegexp('nick list', 'You have no recognized services accounts')
         self.assertNotError('nick add foo')
         self.assertRegexp('nick list', 'foo')
         self.assertNotError('nick add %s bar' % self.nick)


### PR DESCRIPTION
On modern networks, account names are usually separated from your current nick, so the idea of registering "nicks" is confusing. For instance, you can be using a grouped nick that is not your main account name, and WHOIS will only ever show that you are logged in to your main account name.

Also, the bot username is optional in the `add` and `remove` commands - update the docs to reflect that.