### PR TITLE
Channel: Make 'invite' command's required capability configurable

### DIFF
--- a/plugins/Channel/config.py
+++ b/plugins/Channel/config.py
@@ -1,7 +1,7 @@
 ###
 # Copyright (c) 2004-2005, Jeremiah Fincher
 # Copyright (c) 2009, James McCoy
-# Copyright (c) 2010-2021, Valentin Lorentz
+# Copyright (c) 2010-2025, Valentin Lorentz
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -62,5 +62,10 @@ conf.registerChannelValue(Channel, 'partMsg',
         this will be used. If this value is empty, then no part message will
         be used (they are optional in the IRC protocol). The standard
         substitutions ($version, $nick, etc.) are all handled appropriately.""")))
+
+conf.registerGroup(Channel, 'invite')
+conf.registerChannelValue(Channel.invite, 'requireCapability',
+    registry.String('op', _("""Determines what capability (if any) the bot should
+    require people trying to use the 'invite' command to have.""")))
 
 # vim:set shiftwidth=4 softtabstop=4 expandtab textwidth=79:

--- a/plugins/Channel/plugin.py
+++ b/plugins/Channel/plugin.py
@@ -1,7 +1,7 @@
 ###
 # Copyright (c) 2002-2005, Jeremiah Fincher
 # Copyright (c) 2009-2012, James McCoy
-# Copyright (c) 2010-2021, Valentin Lorentz
+# Copyright (c) 2010-2025, Valentin Lorentz
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -508,10 +508,17 @@ class Channel(callbacks.Plugin):
         to join <channel>. <channel> is only necessary if the message isn't
         sent in the channel itself.
         """
+        capability = self.registryValue('invite.requireCapability',
+                                        channel, irc.network)
+        if capability:
+            capability = ircdb.makeChannelCapability(channel, capability)
+            if not ircdb.checkCapability(msg.prefix, capability):
+                irc.errorNoCapability(capability, Raise=True)
+
         nick = nick or msg.nick
         self._sendMsg(irc, ircmsgs.invite(nick, channel))
         self.invites[(irc.getRealIrc(), ircutils.toLower(nick))] = irc
-    invite = wrap(invite, ['op', ('haveHalfop+', _('invite someone')),
+    invite = wrap(invite, [('haveHalfop+', _('invite someone')),
                            additional('nick')])
 
     def do341(self, irc, msg):


### PR DESCRIPTION
It still requires 'op' by default, but can now be changed with a config value.

This can be useful on servers that do not have a 'free invite' channel mode (like Charybdis/Solanum's +g)