### PR TITLE
Remove support for Python 3.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,13 +62,6 @@ jobs:
             with-opt-deps: false
             runs-on: ubuntu-22.04
 
-          - python-version: "3.6"
-            with-opt-deps: false
-            runs-on: ubuntu-20.04
-          - python-version: "pypy-3.6"
-            with-opt-deps: false
-            runs-on: ubuntu-20.04
-
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/setup.py
+++ b/setup.py
@@ -107,8 +107,8 @@ if version:
     fd.write('    pass\n')
     fd.close()
 
-if sys.version_info < (3, 6, 0):
-    sys.stderr.write("Limnoria requires Python 3.6 or newer.")
+if sys.version_info < (3, 7, 0):
+    sys.stderr.write("Limnoria requires Python 3.7 or newer.")
     sys.stderr.write(os.linesep)
     sys.exit(-1)
 
@@ -201,7 +201,6 @@ setup(
         'Operating System :: OS Independent',
         'Operating System :: POSIX',
         'Operating System :: Microsoft :: Windows',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',


### PR DESCRIPTION
Github disabled their Ubuntu 20.04 runners, which means we can't test Python 3.6 in the CI anymore.