### PR TITLE
default oddluck repo: addressing #1628

### DIFF
--- a/plugins/PluginDownloader/plugin.py
+++ b/plugins/PluginDownloader/plugin.py
@@ -218,8 +218,8 @@ repositories = utils.InsensitivePreservingDict({
                                                    'supybot-plugins',
                                                    ),
                'oddluck':          GithubRepository(
-                                                   'oddluck',
-                                                   'limnoria-plugins',
+                                                   'progval',
+                                                   'oddluck-limnoria-plugins',
                                                    ),
                'appas':            GithubRepository(
                                                    'matiasw',


### PR DESCRIPTION
changed oddluck's repo to progval's clone because the profile is private now while keeping 'oddluck' as a repo name.