### PR TITLE
Use importlib.metadata instead of pkg_resources when possible

### DIFF
--- a/src/plugin.py
+++ b/src/plugin.py
@@ -46,9 +46,12 @@ except ImportError:
     else:
         iter_entry_points = pkg_resources.iter_entry_points
 else:
-    def iter_entry_points(group):
-        # Python 3.9 did not support the group= kwarg
-        return importlib.metadata.entry_points().get(group, [])
+    if sys.version_info >= (3, 10):
+        iter_entry_points = importlib.metadata.entry_points
+    else:
+        # works with Python 3.10 and 3.11 too, but not 3.12
+        def iter_entry_points(group):
+            return importlib.metadata.entry_points().get(group, [])
 
 if not hasattr(importlib.util, 'module_from_spec'):
     # Python < 3.5

--- a/src/plugin.py
+++ b/src/plugin.py
@@ -48,7 +48,7 @@ except ImportError:
 else:
     def iter_entry_points(group):
         # Python 3.9 did not support the group= kwarg
-        return importlib.metadata.entry_points()[group]
+        return importlib.metadata.entry_points().get(group, [])
 
 if not hasattr(importlib.util, 'module_from_spec'):
     # Python < 3.5

--- a/src/plugin.py
+++ b/src/plugin.py
@@ -67,7 +67,7 @@ class Deprecated(ImportError):
 def loadPluginFromEntrypoint(name):
     if iter_entry_points is not None:
         for entrypoint_group in ENTRYPOINT_GROUPS:
-            for entrypoint in iter_entry_points(group=entrypoint_group):
+            for entrypoint in iter_entry_points()[entrypoint_group]:
                 if entrypoint.name.lower() == name.lower():
                     return entrypoint.load()
 

--- a/src/plugin.py
+++ b/src/plugin.py
@@ -46,7 +46,9 @@ except ImportError:
     else:
         iter_entry_points = pkg_resources.iter_entry_points
 else:
-    iter_entry_points = importlib.metadata.entry_points
+    def iter_entry_points(group):
+        # Python 3.9 did not support the group= kwarg
+        return importlib.metadata.entry_points()[group]
 
 if not hasattr(importlib.util, 'module_from_spec'):
     # Python < 3.5
@@ -67,7 +69,7 @@ class Deprecated(ImportError):
 def loadPluginFromEntrypoint(name):
     if iter_entry_points is not None:
         for entrypoint_group in ENTRYPOINT_GROUPS:
-            for entrypoint in iter_entry_points()[entrypoint_group]:
+            for entrypoint in iter_entry_points(group=entrypoint_group):
                 if entrypoint.name.lower() == name.lower():
                     return entrypoint.load()
 

--- a/src/plugin.py
+++ b/src/plugin.py
@@ -37,9 +37,16 @@ import linecache
 import importlib.util
 
 try:
-    import pkg_resources
+    import importlib.metadata
 except ImportError:
-    pkg_resources = None
+    try:
+        import pkg_resources
+    except ImportError:
+        iter_entry_points = None
+    else:
+        iter_entry_points = pkg_resources.iter_entry_points
+else:
+    iter_entry_points = importlib.metadata.entry_points
 
 if not hasattr(importlib.util, 'module_from_spec'):
     # Python < 3.5
@@ -58,9 +65,9 @@ class Deprecated(ImportError):
     pass
 
 def loadPluginFromEntrypoint(name):
-    if pkg_resources:
+    if iter_entry_points is not None:
         for entrypoint_group in ENTRYPOINT_GROUPS:
-            for entrypoint in pkg_resources.iter_entry_points(entrypoint_group):
+            for entrypoint in iter_entry_points(group=entrypoint_group):
                 if entrypoint.name.lower() == name.lower():
                     return entrypoint.load()
 

--- a/src/plugin.py
+++ b/src/plugin.py
@@ -35,23 +35,14 @@ import time
 import os.path
 import linecache
 import importlib.util
+import importlib.metadata
 
-try:
-    import importlib.metadata
-except ImportError:
-    try:
-        import pkg_resources
-    except ImportError:
-        iter_entry_points = None
-    else:
-        iter_entry_points = pkg_resources.iter_entry_points
+if sys.version_info >= (3, 10):
+    iter_entry_points = importlib.metadata.entry_points
 else:
-    if sys.version_info >= (3, 10):
-        iter_entry_points = importlib.metadata.entry_points
-    else:
-        # works with Python 3.10 and 3.11 too, but not 3.12
-        def iter_entry_points(group):
-            return importlib.metadata.entry_points().get(group, [])
+    # works with Python 3.10 and 3.11 too, but not 3.12
+    def iter_entry_points(group):
+        return importlib.metadata.entry_points().get(group, [])
 
 if not hasattr(importlib.util, 'module_from_spec'):
     # Python < 3.5


### PR DESCRIPTION
pkg_resources will be removed by setuptools before the end of 2025.

Resolves #1631