### PR TITLE
Replace setup.py with pyproject.toml in the plugin template

### DIFF
--- a/src/scripts/limnoria_plugin_create.py
+++ b/src/scripts/limnoria_plugin_create.py
@@ -184,14 +184,30 @@ configure = config.configure
 # vim:set shiftwidth=4 tabstop=4 expandtab textwidth=79:
 '''.lstrip()
 
-setupTemplate = '''
-%s
+pyprojectTemplate = '''
+[build-system]
+requires = ["setuptools"]
 
-from supybot.setup import plugin_setup
+[project]
+name = "limnoria-%(name_lowercase)s"
+version = "1.0.0"
+authors = [
+    { name = "%(author_name)s" }
+]
+readme = "README.md"
+dependencies = [
+    "limnoria",
+]
 
-plugin_setup(
-    %r,
-)
+[project.entry-points.'limnoria.plugins']
+%(name)s = "limnoria_%(name_lowercase)s"
+
+[tool.setuptools.package-dir]
+"limnoria_%(name_lowercase)s" = "."
+"limnoria_%(name_lowercase)s.local" = "local/"
+
+[tool.setuptools.package-data]
+"limnoria_%(name_lowercase)s" = ["locales/*.po"]
 '''.lstrip()
 
 testTemplate = '''
@@ -296,7 +312,12 @@ def _main():
     writeFile('config.py', configTemplate % (copyright, name, name, name, name,
                                              name))
     writeFile('__init__.py', __init__Template % (copyright, name, options.desc))
-    writeFile('setup.py', setupTemplate % (copyright, name))
+    writeFile('pyproject.toml', pyprojectTemplate % {
+        'copyright': copyright,
+        'name': name,
+        'name_lowercase': name.lower(),
+        'author_name': realName.replace(r'"', r'\"'),  # good enough escape
+    })
     writeFile('test.py', testTemplate % (copyright, name, name))
     writeFile('README.md', readmeTemplate % (options.desc,))
 

--- a/src/scripts/limnoria_plugin_create.py
+++ b/src/scripts/limnoria_plugin_create.py
@@ -190,7 +190,7 @@ requires = ["setuptools"]
 
 [project]
 name = "limnoria-%(name_lowercase)s"
-version = "1.0.0"
+version = "0.0.0"
 authors = [
     { name = "%(author_name)s" }
 ]


### PR DESCRIPTION
setuptools continues the war against its own users and finally managed to break Limnoria.

More specifically, it now has "build isolation" by default, which means that even if users have Limnoria installed,
`from supybot.setup import plugin_setup` fails unless there is a pyproject.toml that contains:

```
[build-system]
requires = ['limnoria', 'setuptools']
```

and then even if we do that, Limnoria's `src/setup.py` crashes while importing the plugin (to read its metadata and class name).

So instead, let's switch to pyproject.toml and hope this doesn't break again in a couple of years.