### PR TITLE
Invalidate importlib caches before attempting to load plugins

### DIFF
--- a/src/plugin.py
+++ b/src/plugin.py
@@ -71,6 +71,11 @@ def loadPluginModule(name, ignoreDeprecation=False):
     pluginDirs = conf.supybot.directories.plugins()[:]
     pluginDirs.append(_pluginsDir)
     module = None
+
+    # Invalidate caches to allow new third party dependencies and plugins to be
+    # located without restarting the bot.
+    importlib.invalidate_caches()
+
     for dir in pluginDirs:
         try:
             files.extend(os.listdir(dir))


### PR DESCRIPTION
This allows newly installed 3rd party dependencies and pip-installed plugins to become visible without restarting the bot. Previously, ImportErrors would be cached if a module was not present when loading it for the first time.

Ref: https://docs.python.org/3/library/importlib.html#importlib.invalidate_caches