### PR TITLE
CI: Update 3.14 from alpha1 to rc2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - python-version: "3.14.0-alpha.1"
+          - python-version: "3.14.0-rc.2"
             with-opt-deps: true
             runs-on: ubuntu-22.04
 

--- a/src/test.py
+++ b/src/test.py
@@ -44,14 +44,9 @@ from . import (callbacks, conf, drivers, httpserver, i18n, ircdb, irclib,
         ircmsgs, ircutils, log, plugin, registry, utils, world)
 from .utils import minisix
 
-if minisix.PY2:
-    from httplib import HTTPConnection
-    from urllib import splithost, splituser
-    from urllib import URLopener
-else:
-    from http.client import HTTPConnection
-    from urllib.parse import splithost, splituser
-    from urllib.request import URLopener
+from http.client import HTTPConnection
+from urllib.parse import splithost, splituser
+from urllib.request import OpenerDirector
 
 class verbosity:
     NONE = 0
@@ -614,7 +609,7 @@ def open_http(url, data=None):
     if proxy_auth: c.putheader('Proxy-Authorization', 'Basic %s' % proxy_auth)
     if auth: c.putheader('Authorization', 'Basic %s' % auth)
     if realhost: c.putheader('Host', realhost)
-    for args in URLopener().addheaders: c.putheader(*args)
+    for args in OpenerDirector().addheaders: c.putheader(*args)
     c.endheaders()
     return c
 

--- a/src/utils/python.py
+++ b/src/utils/python.py
@@ -111,8 +111,8 @@ Synchronized = MetaSynchronized('Synchronized', (), {})
 
 def glob2re(g):
     pattern = fnmatch.translate(g)
-    if pattern.startswith('(?s:') and pattern.endswith(')\\Z'):
-        # Python >= 3.6
+    if pattern.startswith('(?s:') and pattern.endswith((')\\Z', ')\\z')):
+        # \Z from Python 3.6 to 3.13, \z for Python >= 3.14
         return pattern[4:-3] + '\\Z'
     elif pattern.endswith('\\Z(?ms)'):
         # Python >= 2.6 and < 3.6


### PR DESCRIPTION
cffi 2.0 was published this week and broke support for some 3.14 alpha versions. This caused a segfault when trying to use python3-cryptography for ecdsa