### PR TITLE
registry: Add 'settable' argument to make some config variables read-only

### DIFF
--- a/plugins/Config/plugin.py
+++ b/plugins/Config/plugin.py
@@ -72,7 +72,8 @@ def getCapability(irc, name):
     while parts:
         part = parts.pop(0)
         group = group.get(part)
-        if not getattr(group, '_opSettable', True):
+        op_settable = getattr(group, '_opSettable', True)
+        if not utils.force(op_settable):
             return 'owner'
         if irc.isChannel(part):
             # If a registry value has a channel in it, it requires a

--- a/plugins/Config/plugin.py
+++ b/plugins/Config/plugin.py
@@ -82,31 +82,9 @@ def getCapability(irc, name):
         ### Do more later, for specific capabilities/sections.
     return capability
 
-def isReadOnly(name):
-    """Prevents changing certain config variables to gain shell access via
-    a vulnerable IRC network."""
-    parts = registry.split(name.lower())
-    if parts[0] != 'supybot':
-        parts.insert(0, 'supybot')
-    if parts == ['supybot', 'commands', 'allowshell'] and \
-            not conf.supybot.commands.allowShell():
-        # allow setting supybot.commands.allowShell from True to False,
-        # but not from False to True.
-        # Otherwise an IRC network could overwrite it.
-        return True
-    elif parts[0:2] == ['supybot', 'directories'] and \
-            not conf.supybot.commands.allowShell():
-        # Setting plugins directory allows for arbitrary code execution if
-        # an attacker can both use the IRC network to MITM and upload files
-        # on the server (eg. with a web CMS).
-        # Setting other directories allows writing data at arbitrary
-        # locations.
-        return True
-    else:
-        return False
-
 def checkCanSetValue(irc, msg, group):
-    if isReadOnly(group._name):
+    settable = getattr(group, '_settable', True)
+    if not utils.force(settable):
         irc.error(_("This configuration variable is not writeable "
             "via IRC. To change it you have to: 1) use the 'flush' command 2) edit "
             "the config file 3) use the 'config reload' command."), Raise=True)

--- a/src/conf.py
+++ b/src/conf.py
@@ -85,15 +85,17 @@ def registerGroup(Group, name, group=None, **kwargs):
         group = registry.Group(**kwargs)
     return Group.register(name, group)
 
-def registerGlobalValue(group, name, value):
+def registerGlobalValue(group, name, value, settable=True):
     value._networkValue = False
     value._channelValue = False
+    value._settable = settable
     return group.register(name, value)
 
-def registerNetworkValue(group, name, value):
+def registerNetworkValue(group, name, value, settable=True):
     value._supplyDefault = True
     value._networkValue = True
     value._channelValue = False
+    value._settable = settable
     g = group.register(name, value)
     gname = g._name.lower()
     for name in registry._cache.keys():
@@ -105,11 +107,12 @@ def registerNetworkValue(group, name, value):
                 g.get(parts[0])()
     return g
 
-def registerChannelValue(group, name, value, opSettable=True):
+def registerChannelValue(group, name, value, opSettable=True, settable=True):
     value._supplyDefault = True
     value._networkValue = True
     value._channelValue = True
     value._opSettable = opSettable
+    value._settable = settable
     g = group.register(name, value)
     gname = g._name.lower()
     for name in registry._cache.keys():
@@ -868,7 +871,8 @@ registerGlobalValue(supybot.commands, 'allowShell',
     to prevent MITM from the IRC network itself (vulnerable IRCd or IRCops)
     from gaining shell access to the bot's server by impersonating the owner.
     Setting this to False also disables plugins and commands that can be
-    used to indirectly gain shell access.""")))
+    used to indirectly gain shell access.""")),
+    settable=lambda: supybot.commands.allowShell())
 
 # supybot.commands.disabled moved to callbacks for canonicalName.
 
@@ -991,22 +995,28 @@ class DataFilenameDirectory(DataFilename, Directory):
 registerGroup(supybot, 'directories')
 registerGlobalValue(supybot.directories, 'conf',
     Directory('conf', _("""Determines what directory configuration data is
-    put into.""")))
+    put into.""")),
+    settable=lambda: supybot.commands.allowShell())
 registerGlobalValue(supybot.directories, 'data',
-    Directory('data', _("""Determines what directory data is put into.""")))
+    Directory('data', _("""Determines what directory data is put into.""")),
+    settable=lambda: supybot.commands.allowShell())
 registerGlobalValue(supybot.directories, 'backup',
     Directory('backup', _("""Determines what directory backup data is put
     into. Set it to /dev/null to disable backup (it is a special value,
-    so it also works on Windows and systems without /dev/null).""")))
+    so it also works on Windows and systems without /dev/null).""")),
+    settable=lambda: supybot.commands.allowShell())
 registerGlobalValue(supybot.directories, 'log',
-    Directory('logs', """Determines what directory the bot will store its
-    logfiles in."""))
+    Directory('logs', _("""Determines what directory the bot will store its
+    logfiles in.""")),
+    settable=lambda: supybot.commands.allowShell())
 registerGlobalValue(supybot.directories.data, 'tmp',
     DataFilenameDirectory('tmp', _("""Determines what directory temporary files
-    are put into.""")))
+    are put into.""")),
+    settable=lambda: supybot.commands.allowShell())
 registerGlobalValue(supybot.directories.data, 'web',
     DataFilenameDirectory('web', _("""Determines what directory files of the
-    web server (templates, custom images, ...) are put into.""")))
+    web server (templates, custom images, ...) are put into.""")),
+    settable=lambda: supybot.commands.allowShell())
 
 def _update_tmp():
     utils.file.AtomicFile.default.tmpDir = supybot.directories.data.tmp
@@ -1023,7 +1033,8 @@ registerGlobalValue(supybot.directories, 'plugins',
     strings.
     This means that to add another directory, you can nest the former value and
     add a new one.  E.g. you can say: bot: 'config supybot.directories.plugins
-    [config supybot.directories.plugins], newPluginDirectory'.""")))
+    [config supybot.directories.plugins], newPluginDirectory'.""")),
+    settable=lambda: supybot.commands.allowShell())
 
 registerGlobalValue(supybot, 'plugins',
     registry.SpaceSeparatedSetOfStrings([], _("""List of all plugins that were
@@ -1036,7 +1047,8 @@ registerGlobalValue(supybot.plugins, 'alwaysLoadImportant',
     regardless of what their configured state is.  Generally, if these plugins
     are configured not to load, you didn't do it on purpose, and you still
     want them to load.  Users who don't want to load these plugins are smart
-    enough to change the value of this variable appropriately :)""")))
+    enough to change the value of this variable appropriately :)""")),
+    settable=lambda: supybot.commands.allowShell())
 
 ###
 # supybot.databases.  For stuff relating to Supybot's databases (duh!)

--- a/src/registry.py
+++ b/src/registry.py
@@ -339,7 +339,8 @@ class Value(Group):
     """Invalid registry value.  If you're getting this message, report it,
     because we forgot to put a proper help string here."""
     __slots__ = ('__parent', '_default', '_showDefault', '_help', '_callbacks',
-            'value', '_networkValue', '_channelValue', '_opSettable')
+            'value', '_networkValue', '_channelValue', '_opSettable',
+            '_settable')
     def __init__(self, default, help, setDefault=True,
                  showDefault=True, **kwargs):
         self.__parent = super(Value, self)


### PR DESCRIPTION
This removes the special-case in the Config plugin for variables that should not be changed when supybot.commands.allowShell is False

I'm not fond of the name. Should I rename it to something like `readOnly`?