### PR TITLE
Exclude CTCP and formatting characters from URL regexp

### DIFF
--- a/plugins/Web/test.py
+++ b/plugins/Web/test.py
@@ -102,6 +102,16 @@ class WebTestCase(ChannelPluginTestCase):
             finally:
                 conf.supybot.plugins.Web.titleSnarfer.setValue(False)
 
+        def testTitleSnarferCtcp(self):
+            try:
+                conf.supybot.plugins.Web.titleSnarfer.setValue(True)
+                self.assertSnarfRegexp(
+                    '\x01ACTION is browsing https://microsoft.com/\x01',
+                    'Microsoft'
+                )
+            finally:
+                conf.supybot.plugins.Web.titleSnarfer.setValue(False)
+
         def testMultipleTitleSnarfer(self):
             try:
                 conf.supybot.plugins.Web.titleSnarfer.setValue(True)

--- a/src/utils/web.py
+++ b/src/utils/web.py
@@ -88,7 +88,7 @@ _domain = r'%s(?:\.%s)*\.[0-9a-z][-0-9a-z]+' % (_label, _label)
 _urlRe = r'(%s://(?:\S+@)?(?:%s|%s)(?::\d+)?(?:/[^\])>\s]*)?)' % (
         _scheme, _domain, _ipAddr)
 urlRe = re.compile(_urlRe, re.I)
-_httpUrlRe = r'(https?://(?:\S+@)?(?:%s|%s)(?::\d+)?(?:/[^\]>\s]*)?)' % \
+_httpUrlRe = r'(https?://(?:\S+@)?(?:%s|%s)(?::\d+)?(?:/[^\]>\s\x00-\x1f]*)?)' % \
              (_domain, _ipAddr)
 httpUrlRe = re.compile(_httpUrlRe, re.I)
 


### PR DESCRIPTION
This prevents the regexp from being too greedy when a URL is at the end of a /me or just before a color/formatting code.

Closes #1670 