### PR TITLE
Services: Fix config initialization

### DIFF
--- a/plugins/Services/plugin.py
+++ b/plugins/Services/plugin.py
@@ -70,14 +70,11 @@ class Services(callbacks.Plugin):
     def __init__(self, irc):
         self.__parent = super(Services, self)
         self.__parent.__init__(irc)
+        self._initializedNetworks = set()
         self.reset()
 
     def reset(self):
         self.state = {}
-
-    def do001(self, irc, msg):
-        for nick in self.registryValue('nicks', network=irc.network):
-            config.registerNick(nick)
 
     def _getState(self, irc):
         return self.state.setdefault(irc.network, State())
@@ -187,6 +184,12 @@ class Services(callbacks.Plugin):
         self.__parent.__call__(irc, msg)
         if self.disabled(irc):
             return
+
+        if irc.network not in self._initializedNetworks:
+            self._initializedNetworks.add(irc.network)
+            for nick in self.registryValue('nicks', network=irc.network):
+                config.registerNick(nick)
+
         state = self._getState(irc)
         nick = self._getNick(irc.network)
         if nick not in self.registryValue('nicks', network=irc.network):

--- a/plugins/Unix/config.py
+++ b/plugins/Unix/config.py
@@ -72,7 +72,8 @@ Unix = conf.registerPlugin('Unix')
 conf.registerGroup(Unix, 'fortune')
 conf.registerGlobalValue(Unix.fortune, 'command',
     registry.String(utils.findBinaryInPath('fortune') or '', _("""Determines
-    what command will be called for the fortune command.""")))
+    what command will be called for the fortune command.""")),
+    settable=lambda: conf.supybot.commands.allowShell())
 conf.registerChannelValue(Unix.fortune, 'short',
     registry.Boolean(True, _("""Determines whether only short fortunes will be
     used if possible.  This sends the -s option to the fortune program.""")))
@@ -95,7 +96,8 @@ conf.registerGroup(Unix, 'spell')
 conf.registerGlobalValue(Unix.spell, 'command',
     registry.String(utils.findBinaryInPath('aspell') or
                     utils.findBinaryInPath('ispell') or '', _("""Determines
-    what command will be called for the spell command.""")))
+    what command will be called for the spell command.""")),
+    settable=lambda: conf.supybot.commands.allowShell())
 conf.registerGlobalValue(Unix.spell, 'language',
     registry.String('en', _("""Determines what aspell dictionary will be used
     for spell checking.""")))
@@ -103,28 +105,33 @@ conf.registerGlobalValue(Unix.spell, 'language',
 conf.registerGroup(Unix, 'wtf')
 conf.registerGlobalValue(Unix.wtf, 'command',
     registry.String(utils.findBinaryInPath('wtf') or '', _("""Determines what
-    command will be called for the wtf command.""")))
+    command will be called for the wtf command.""")),
+    settable=lambda: conf.supybot.commands.allowShell())
 
 conf.registerGroup(Unix, 'ping')
-conf.registerGlobalValue(Unix.ping, 'command', 
-    registry.String(utils.findBinaryInPath('ping') or '', """Determines what 
-    command will be called for the ping command."""))
+conf.registerGlobalValue(Unix.ping, 'command',
+    registry.String(utils.findBinaryInPath('ping') or '', """Determines what
+    command will be called for the ping command."""),
+    settable=lambda: conf.supybot.commands.allowShell())
 conf.registerGlobalValue(Unix.ping, 'defaultCount',
     registry.PositiveInteger(5, """Determines what ping and ping6 counts (-c) will default to."""))
 
 conf.registerGroup(Unix, 'ping6')
-conf.registerGlobalValue(Unix.ping6, 'command', 
-    registry.String(utils.findBinaryInPath('ping6') or '', """Determines what 
-    command will be called for the ping6 command."""))
+conf.registerGlobalValue(Unix.ping6, 'command',
+    registry.String(utils.findBinaryInPath('ping6') or '', """Determines what
+    command will be called for the ping6 command."""),
+    settable=lambda: conf.supybot.commands.allowShell())
 
 conf.registerGroup(Unix, 'sysuptime')
 conf.registerGlobalValue(Unix.sysuptime, 'command',
     registry.String(utils.findBinaryInPath('uptime') or '', """Determines what
-    command will be called for the uptime command."""))
+    command will be called for the uptime command."""),
+    settable=lambda: conf.supybot.commands.allowShell())
 
 conf.registerGroup(Unix, 'sysuname')
 conf.registerGlobalValue(Unix.sysuname, 'command',
     registry.String(utils.findBinaryInPath('uname') or '', """Determines what
-    command will be called for the uname command."""))
+    command will be called for the uname command."""),
+    settable=lambda: conf.supybot.commands.allowShell())
 
 # vim:set shiftwidth=4 softtabstop=4 expandtab textwidth=79:


### PR DESCRIPTION
Fixes 026dbf314aac459466264ceb97b1ca7c83c497fb which never actually ran as there is already a method named do001 defined later in the file, which overrode this.

Additionally, do001 is not the right place to initialize, because __call__ is called for earlier messages (connection registration) and needs to access the config values

Closes #1672