### PR TITLE
CI: Update max PyPy version, and stop installing python-cryptography on old PyPy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,14 +34,14 @@ jobs:
           - python-version: "3.11"
             with-opt-deps: true
             runs-on: ubuntu-22.04
+          - python-version: "pypy-3.11"
+            with-opt-deps: true
+            runs-on: ubuntu-22.04
 
           - python-version: "3.10"
             with-opt-deps: true
             runs-on: ubuntu-22.04
           - python-version: "3.10"
-            with-opt-deps: false
-            runs-on: ubuntu-22.04
-          - python-version: "pypy-3.10"
             with-opt-deps: false
             runs-on: ubuntu-22.04
 
@@ -49,7 +49,7 @@ jobs:
             with-opt-deps: true
             runs-on: ubuntu-22.04
           - python-version: "pypy-3.9"
-            with-opt-deps: true
+            with-opt-deps: false
             runs-on: ubuntu-22.04
 
     steps:

--- a/src/utils/net.py
+++ b/src/utils/net.py
@@ -192,7 +192,15 @@ def ssl_wrap_socket(conn, hostname, logger, certfile=None,
         conn = context.wrap_socket(conn, server_hostname=hostname)
 
     if trusted_fingerprints:
-        check_certificate_fingerprint(conn, trusted_fingerprints)
+        try:
+            check_certificate_fingerprint(conn, trusted_fingerprints)
+        except:
+            # We need to explicitly close the SSL wrapper here, because we
+            # don't return it to the caller.
+            # Without it, current PyPy versions won't close the underlying
+            # socket until this wrapper gets garbage-collected.
+            conn.close()
+            raise
 
     return conn
 


### PR DESCRIPTION
It fails with: 'error: the configured PyPy interpreter version (3.9) is lower than PyO3's minimum supported version (3.11)'